### PR TITLE
fix: 플레이어 피해가 두 번 적용되는 문제 수정

### DIFF
--- a/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
@@ -816,11 +816,15 @@ void ACC_PlayerCharacter::UpdateGameHUD()
 
 float ACC_PlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
-	float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+	const float PreviousHealth = CurrentHealth;
+	const float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
 
-	CurrentHealth = FMath::Max(0.0f, CurrentHealth - ActualDamage);
-
-	UpdateGameHUD();
+	// Base character damage flow owns health reduction and death checks.
+	// The player override only syncs the HUD after health actually changes.
+	if (ActualDamage > 0.0f && !FMath::IsNearlyEqual(CurrentHealth, PreviousHealth))
+	{
+		UpdateGameHUD();
+	}
 
 	return ActualDamage;
 }


### PR DESCRIPTION
## 배경

안녕하세요. 플레이어 피격 흐름을 확인하던 중, 플레이어가 한 번의 공격에 대해 실제 체력을 두 번 차감받을 수 있는 문제가 보여 이번 수정안을 올립니다.

원인은 공용 캐릭터 데미지 처리인 `ACC_Character::TakeDamage()` 에서 이미 `CurrentHealth` 를 차감하고 있는데, 플레이어 전용 오버라이드인 `ACC_PlayerCharacter::TakeDamage()` 에서 `Super::TakeDamage()` 호출 이후 같은 `ActualDamage` 를 다시 차감하고 있었기 때문입니다.

이 상태에서는 같은 공격 이벤트라도 플레이어만 공용 데미지 흐름과 다르게 동작하게 되어, 밸런스 확인이나 디버깅 시 혼동을 만들 수 있다고 판단했습니다.

## 수정 내용

- `ACC_Character::TakeDamage()` 를 실제 체력 감소와 사망 판정의 단일 진입점으로 유지했습니다.
- `ACC_PlayerCharacter::TakeDamage()` 에서 중복으로 수행하던 체력 차감 로직을 제거했습니다.
- 플레이어 오버라이드는 체력 변경 이후 HUD 동기화만 담당하도록 정리했습니다.
- 코드만 보더라도 역할이 드러나도록, 베이스 클래스는 데미지/사망 처리, 플레이어 클래스는 HUD 반영이라는 의도를 주석으로 남겼습니다.

## 리뷰 시 집중해서 봐주시면 좋은 부분

- `ACC_Character::TakeDamage()` 만이 `CurrentHealth` 를 실제로 감소시키는 구조가 맞는지
- `ACC_PlayerCharacter::TakeDamage()` 가 더 이상 데미지를 재적용하지 않고 HUD 갱신만 수행하는지
- 플레이어 체력이 `0` 이 되었을 때 기존 사망 처리 흐름이 그대로 유지되는지

## 재현 방법

수정 전 기준입니다.

1. 게임을 실행합니다.
2. 적이 플레이어에게 한 번 공격을 적중시키도록 합니다.
3. 플레이어 데미지 흐름을 따라가면 `ACC_Character::TakeDamage()` 에서 먼저 체력이 1회 감소합니다.
4. 이후 `ACC_PlayerCharacter::TakeDamage()` 로 복귀한 뒤 동일한 `ActualDamage` 가 다시 한 번 차감됩니다.
5. 결과적으로 플레이어는 한 번 맞았는데도 의도보다 큰 체력 감소를 겪게 됩니다.

## 수정 후 기대 결과

1. 적의 단일 공격이 플레이어 데미지 흐름으로 들어옵니다.
2. `ACC_Character::TakeDamage()` 에서 체력 감소가 정확히 1회만 수행됩니다.
3. 이어서 `ACC_PlayerCharacter::TakeDamage()` 는 변경된 체력을 HUD에 반영만 합니다.
4. 결과적으로 한 번의 피격은 한 번의 체력 감소만 만들고, HUD 갱신 및 사망 처리는 기존 흐름을 유지합니다.

## 검증 내용

- 코드 경로 확인
- `ACC_Character::TakeDamage()` 에서 이미 체력 감소 및 사망 판정이 수행되는 점을 확인했습니다.
- 적의 공격 경로가 `Player->TakeDamage(...)` 를 통해 동일한 공용 데미지 흐름으로 진입하는 점을 확인했습니다.
- 플레이어 오버라이드에서 추가로 수행되던 `CurrentHealth -= ActualDamage` 성격의 중복 차감 로직이 제거된 것을 확인했습니다.
- 변경사항 점검
- `git diff --check` 를 실행해 diff 상의 공백/형식 문제는 없음을 확인했습니다.

## 남아 있을 수 있는 리스크 / 후속 확인 사항

- 이번 PR은 원인 제거에 집중한 최소 수정입니다. 데미지 파이프라인 전반을 넓게 리팩터링하지는 않았습니다.
- 블루프린트나 에디터 상의 별도 피격 연출/연동이 있다면, 실제 플레이에서 HUD 반영 타이밍이 기존 기대와 동일한지 한 번 더 스모크 테스트해보면 좋겠습니다.
- 현재 작업 환경에는 Unreal Editor / UnrealBuildTool 이 없어 실제 빌드 및 인게임 검증은 수행하지 못했습니다. 이 부분은 리뷰 환경에서 함께 확인 부탁드립니다.
