### PR TITLE
fix: 반복 스탯 재적용 시 계산 드리프트 방지

### DIFF
--- a/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
@@ -140,6 +140,18 @@ void ACC_PlayerCharacter::ApplyPlayerStats()
 	ApplyStats();
 }
 
+void ACC_PlayerCharacter::InitializeBasePlayerStats()
+{
+	if (bBasePlayerStatsInitialized)
+	{
+		return;
+	}
+
+	BaseMaxHealth = MaxHealth;
+	BaseMoveSpeed = MoveSpeed;
+	bBasePlayerStatsInitialized = true;
+}
+
 void ACC_PlayerCharacter::InitializeWeaponSystem()
 {
 	UGameInstance* GameInstance = GetGameInstance();
@@ -954,29 +966,41 @@ void ACC_PlayerCharacter::ApplyStats()
 {
 	Super::ApplyStats();
 
+	InitializeBasePlayerStats();
+
+	const float PreviousMaxHealth = MaxHealth;
+	const bool bHadValidPreviousMaxHealth = PreviousMaxHealth > 0.0f;
+	const bool bWasAtFullHealth = bHadValidPreviousMaxHealth
+		&& FMath::IsNearlyEqual(CurrentHealth, PreviousMaxHealth);
+	const float PreviousHealthRatio = bHadValidPreviousMaxHealth
+		? FMath::Clamp(CurrentHealth / PreviousMaxHealth, 0.0f, 1.0f)
+		: 0.0f;
+
+	const float FinalMoveSpeed = BaseMoveSpeed * PlayerStats.BasicStats.MoveSpeedMultiplier;
+
 	if (UCharacterMovementComponent* Movement = GetCharacterMovement())
 	{
-		float FinalMoveSpeed = MoveSpeed * PlayerStats.BasicStats.MoveSpeedMultiplier;
 		Movement->MaxWalkSpeed = FinalMoveSpeed;
 	}
 
-	// Apply health multiplier
-	float FinalMaxHealth = MaxHealth * PlayerStats.BasicStats.HealthMultiplier;
+	const float FinalMaxHealth = BaseMaxHealth * PlayerStats.BasicStats.HealthMultiplier;
+	MaxHealth = FinalMaxHealth;
 
-	// If health was at max, keep it at max after stat change
-	if (FMath::IsNearlyEqual(CurrentHealth, MaxHealth))
+	if (FMath::IsNearlyZero(FinalMaxHealth))
+	{
+		CurrentHealth = 0.0f;
+	}
+	else if (bWasAtFullHealth)
 	{
 		CurrentHealth = FinalMaxHealth;
 	}
 	else
 	{
-		// Otherwise, adjust current health proportionally
-		float HealthPercentage = CurrentHealth / MaxHealth;
-		CurrentHealth = FinalMaxHealth * HealthPercentage;
+		CurrentHealth = FinalMaxHealth * PreviousHealthRatio;
+		CurrentHealth = FMath::Clamp(CurrentHealth, 0.0f, FinalMaxHealth);
 	}
 
-	MaxHealth = FinalMaxHealth;
-
-	UE_LOG(LogTemp, Log, TEXT("Stats Applied - Health: %.0f/%.0f, Speed: %.0f"),
-		CurrentHealth, MaxHealth, GetCharacterMovement()->MaxWalkSpeed);
+	UE_LOG(LogTemp, Log,
+		TEXT("Stats Applied - BaseHealth: %.0f, FinalHealth: %.0f/%.0f, BaseSpeed: %.0f, FinalSpeed: %.0f"),
+		BaseMaxHealth, CurrentHealth, MaxHealth, BaseMoveSpeed, FinalMoveSpeed);
 }

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.h
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.h
@@ -44,9 +44,20 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Stats")
 	FCristalCubePlayerStats PlayerStats;
 
+	// Stable, pre-multiplier values used as the source of truth for repeated stat application.
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Stats")
+	float BaseMaxHealth = 0.0f;
+
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Stats")
+	float BaseMoveSpeed = 0.0f;
+
+	bool bBasePlayerStatsInitialized = false;
+
 	// Apply stats to character (called when stats change)
 	UFUNCTION(BlueprintCallable, Category = "Stats")
 	void ApplyPlayerStats();
+
+	void InitializeBasePlayerStats();
 
 	// Getters
 	UFUNCTION(BlueprintCallable, Category = "Stats")


### PR DESCRIPTION
## 요약
이번 PR은 `ACC_PlayerCharacter::ApplyStats()` 가 여러 번 호출될 때 이미 적용된 값을 다시 기준값처럼 사용하면서 `MaxHealth` 같은 수치가 계속 누적 곱으로 커지는 문제를 수정합니다.

이번 변경은 밸런스 수치 조정이 아니라, 동일한 스탯을 여러 번 재적용해도 항상 같은 결과가 나오도록 계산을 안정화하는 작업입니다. 의도한 multiplier 값 자체는 바꾸지 않았고, 적용 기준만 안전하게 정리했습니다.

## 왜 이 버그가 위험한가
- 플레이어 스탯을 다시 적용하는 경로가 한 번이라도 추가되면, 호출 횟수에 따라 실제 능력치가 달라질 수 있습니다.
- 특히 체력처럼 생존에 직접 연결되는 수치가 조용히 부풀어 오르기 때문에, 플레이 중에는 원인을 찾기 어렵고 밸런스 이상처럼 보일 수 있습니다.
- 호출 순서나 횟수에 따라 결과가 달라지는 구조라서, 이후에 스탯 보너스 종류가 늘어나거나 재적용 타이밍이 추가될수록 디버깅 난도가 크게 올라갑니다.

## 기존 계산 방식과 변경 후 계산 방식
### 변경 전
- `ApplyStats()` 가 `MaxHealth * HealthMultiplier` 로 최종 체력을 계산했습니다.
- 그런데 직전 적용 결과를 `MaxHealth` 에 다시 저장하고 있었기 때문에, 다음 호출에서는 이미 증폭된 값을 다시 곱하게 됐습니다.
- 예를 들어 기본 체력 `100`, 체력 배수 `1.5` 인 상태에서 같은 적용이 3번 일어나면:
  - 1회 적용: `100 -> 150`
  - 2회 적용: `150 -> 225`
  - 3회 적용: `225 -> 337.5`
- 현재 체력 비율 유지 로직도 이 커진 `MaxHealth` 를 기준으로 따라가기 때문에, 겉으로는 비율이 맞아 보여도 절대값은 계속 틀어질 수 있었습니다.

### 변경 후
- 플레이어가 가진 원래 기준값을 `BaseMaxHealth`, `BaseMoveSpeed` 로 한 번만 저장해 두고, 이후에는 항상 이 값을 기준으로 최종 수치를 다시 계산합니다.
- 그래서 같은 multiplier 를 여러 번 적용해도 최종 결과는 매번 동일합니다.
- 같은 예시에서 기본 체력 `100`, 체력 배수 `1.5` 를 3번 적용하면:
  - 1회 적용: `100 -> 150`
  - 2회 적용: `150 -> 150`
  - 3회 적용: `150 -> 150`
- 기존에 의도했던 체력 처리도 유지했습니다.
  - 재적용 직전 체력이 가득 찬 상태였다면, 재적용 후에도 가득 찬 상태를 유지합니다.
  - 가득 차지 않은 상태였다면, 이전 최종 최대 체력 대비 체력 비율을 유지해서 다시 계산합니다.

## 리뷰 포인트
- `BaseMaxHealth`, `BaseMoveSpeed` 를 반복 적용의 기준값으로 캐시한 방식이 안전한지
- `MaxHealth` 가 더 이상 이전 적용 결과를 다시 곱하는 구조가 아니고, 항상 base 값에서 재계산되는지
- 체력 비율 유지 로직이 기존 의도를 해치지 않으면서도 반복 적용에 대해 안정적으로 동작하는지
- 지금은 이동속도/체력 중심이지만, 이후 다른 스탯 재적용이 추가되어도 같은 방향으로 확장하기 쉬운 구조인지

## 검증 내용
- `CC_PlayerCharacter.h/.cpp` 기준으로 스탯 재적용 흐름을 직접 확인했습니다.
- `git diff --check` 통과로 기본적인 패치 정합성을 확인했습니다.
- 반복 적용 수치 검증:
  - Full HP, base `100`, multiplier `1.5`, 3회 적용
    - 변경 전: `337.50 / 337.50`
    - 변경 후: `150.00 / 150.00`
  - Half HP, base `100`, multiplier `1.5`, 3회 적용
    - 변경 전: `168.75 / 337.50`
    - 변경 후: `75.00 / 150.00`
  - Low HP, base `100`, multiplier `1.5`, 3회 적용
    - 변경 전: `84.38 / 337.50`
    - 변경 후: `37.50 / 150.00`
- 로컬 Unreal 빌드는 현재 환경에 Unreal build toolchain / editor 가 없어 실행하지 못했습니다.
