### PR TITLE
fix: 실제 적 사망일 때만 사이클 킬 카운트 증가

### DIFF
--- a/Source/CristalCube/CC_CycleManager.cpp
+++ b/Source/CristalCube/CC_CycleManager.cpp
@@ -60,21 +60,24 @@ void ACC_CycleManager::BindToEnemyManager()
         return;
     }
 
-    EM->OnEnemyUnregistered.AddDynamic(this, &ACC_CycleManager::OnEnemyKilled);
-    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Bound to EnemyManager::OnEnemyUnregistered."));
+    EM->OnEnemyKilled.AddUniqueDynamic(this, &ACC_CycleManager::OnEnemyKilled);
+    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Bound to EnemyManager::OnEnemyKilled."));
 }
 
 void ACC_CycleManager::OnEnemyKilled(AActor* KilledEnemy)
 {
-    if (!bCycleActive) return;
+    if (!bCycleActive)
+    {
+        return;
+    }
 
     ++KillsThisCycle;
     ++TotalKills;
 
     OnKillCountUpdated.Broadcast(KillsThisCycle, GetKillsRequired());
 
-    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Kill %d / %d"),
-        KillsThisCycle, GetKillsRequired());
+    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Counted confirmed kill for %s (%d / %d)"),
+        *GetNameSafe(KilledEnemy), KillsThisCycle, GetKillsRequired());
 
     CheckCycleCompletion();
 }

--- a/Source/CristalCube/CC_CycleManager.h
+++ b/Source/CristalCube/CC_CycleManager.h
@@ -50,7 +50,8 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnKillCountUpdated, int32, Current
  * CC_MainGameMode에서 Spawn하여 참조.
  *
  * EnemyManager 연동:
- *   EnemyManager::OnEnemyUnregistered → OnEnemyKilled() 자동 호출
+ *   EnemyCharacter::Die() → EnemyManager::ReportEnemyKilled()
+ *   EnemyManager::OnEnemyKilled → OnEnemyKilled() 자동 호출
  *   EnemyCharacter/CycleManager 간 직접 의존 없음
  *
  * 사이클 흐름:
@@ -152,7 +153,7 @@ private:
     void StartCycle(int32 CycleNumber);
     void CheckCycleCompletion();
 
-    /** 적 처치 시 호출 (EnemyCharacter 사망 시 연결) */
+    /** 실제 적 사망 시 호출 (cleanup unregister는 제외) */
     UFUNCTION(BlueprintCallable, Category = "Cycle")
     void OnEnemyKilled(AActor* KilledEnemy);
 

--- a/Source/CristalCube/CC_EnemyManager.cpp
+++ b/Source/CristalCube/CC_EnemyManager.cpp
@@ -121,10 +121,29 @@ void ACC_EnemyManager::UnregisterEnemy(AActor* Enemy)
 
     PendingRemoval.Add(Enemy);
 
-    // CycleManager에 킬 알림 (직접 참조 없이 델리게이트로)
     OnEnemyUnregistered.Broadcast(Enemy);
 
-    UE_LOG(LogTemp, VeryVerbose, TEXT("[ENEMY MANAGER] Unregistered enemy (Total: %d)"), ActiveEnemies.Num());
+    UE_LOG(LogTemp, VeryVerbose, TEXT("[ENEMY MANAGER] Unregistered enemy for cleanup: %s (Tracked: %d)"),
+        *GetNameSafe(Enemy), ActiveEnemies.Num());
+}
+
+void ACC_EnemyManager::ReportEnemyKilled(AActor* Enemy)
+{
+    if (!Enemy)
+    {
+        return;
+    }
+
+    if (!ActiveEnemies.Contains(Enemy))
+    {
+        UE_LOG(LogTemp, Warning, TEXT("[ENEMY MANAGER] Ignored kill report for untracked enemy: %s"),
+            *GetNameSafe(Enemy));
+        return;
+    }
+
+    OnEnemyKilled.Broadcast(Enemy);
+
+    UE_LOG(LogTemp, Log, TEXT("[ENEMY MANAGER] Confirmed enemy death: %s"), *GetNameSafe(Enemy));
 
 }
 

--- a/Source/CristalCube/CC_EnemyManager.h
+++ b/Source/CristalCube/CC_EnemyManager.h
@@ -7,6 +7,7 @@
 #include "CC_EnemyManager.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnemyUnregistered, AActor*, Enemy);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnemyKilled, AActor*, Enemy);
 /**
  * Central manager for all enemies
  * Provides optimized enemy queries for weapons
@@ -67,9 +68,13 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Enemy Manager")
     void RegisterEnemy(AActor* Enemy);
 
-    // Unregister enemy (called by enemy on death/destroy)
+    // Unregister enemy from tracking (called during cleanup/end play)
     UFUNCTION(BlueprintCallable, Category = "Enemy Manager")
     void UnregisterEnemy(AActor* Enemy);
+
+    // Report a confirmed enemy death (called only from actual death flow)
+    UFUNCTION(BlueprintCallable, Category = "Enemy Manager")
+    void ReportEnemyKilled(AActor* Enemy);
 
     // Get nearest enemy to location (FAST!)
     UFUNCTION(BlueprintPure, Category = "Enemy Manager")
@@ -89,6 +94,9 @@ public:
 
     UPROPERTY(BlueprintAssignable, Category = "Enemy Manager")
     FOnEnemyUnregistered OnEnemyUnregistered;
+
+    UPROPERTY(BlueprintAssignable, Category = "Enemy Manager")
+    FOnEnemyKilled OnEnemyKilled;
 
 protected:
     // Update cache

--- a/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
@@ -159,6 +159,26 @@ void ACC_EnemyCharacter::EndPlay(const EEndPlayReason::Type EndPlayReason)
 	Super::EndPlay(EndPlayReason);
 }
 
+void ACC_EnemyCharacter::ReportActualDeathToEnemyManager()
+{
+	if (bReportedActualDeath)
+	{
+		return;
+	}
+
+	bReportedActualDeath = true;
+
+	if (ACC_EnemyManager* Manager = ACC_EnemyManager::Get(this))
+	{
+		Manager->ReportEnemyKilled(this);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[ENEMY] Failed to report actual death for %s - EnemyManager missing"),
+			*GetName());
+	}
+}
+
 void ACC_EnemyCharacter::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
@@ -460,6 +480,8 @@ void ACC_EnemyCharacter::DealContactDamage(AActor* OtherActor)
 
 void ACC_EnemyCharacter::Die()
 {
+	ReportActualDeathToEnemyManager();
+
 
 	// Drop experience for player
 	//if (TargetPlayer && ExperienceDrop > 0.0f)

--- a/Source/CristalCube/Characters/CC_EnemyCharacter.h
+++ b/Source/CristalCube/Characters/CC_EnemyCharacter.h
@@ -28,6 +28,8 @@ public:
 
 protected:
 
+	bool bReportedActualDeath = false;
+
 	// Target player reference
 	UPROPERTY()
 	class ACC_PlayerCharacter* TargetPlayer;
@@ -101,6 +103,8 @@ protected:
 
 	// Override Die() to drop experience
 	virtual void Die() override;
+
+	void ReportActualDeathToEnemyManager();
 
 
 protected:


### PR DESCRIPTION
## 요약
이번 PR은 사이클 킬 카운트가 `Enemy unregister` 시점이 아니라, 적이 **실제로 사망한 경우에만** 증가하도록 수정한 내용입니다.

기존에는 적이 매니저에서 제거되기만 해도 킬로 집계될 수 있어서, 레벨 정리, 강제 `Destroy`, `EndPlay` 같은 정리 경로에서도 킬 수가 잘못 올라가는 문제가 있었습니다. 이번 변경으로 "추적 해제"와 "실제 사망"을 코드상 명확히 분리했습니다.

## 기존 방식의 문제
기존 구조에서는 `ACC_CycleManager` 가 `ACC_EnemyManager::OnEnemyUnregistered` 에 직접 바인딩되어 있었습니다.

이 구조에서는 아래 경우가 모두 킬로 오인될 수 있었습니다.
- 적이 정상 사망 후 `SetLifeSpan` / `Destroy` / `EndPlay` 로 정리되는 경우
- 레벨 종료, 월드 정리, 매니저 종료 같은 전체 정리 흐름
- 실제 전투 사망이 아닌 강제 제거 경로에서 `UnregisterEnemy()` 만 호출되는 경우

즉, 기존 구현은 `"매니저에서 빠졌다"` 와 `"적이 죽었다"` 를 같은 이벤트로 취급하고 있었고, 이 때문에 사이클 킬 수가 실제 전투 결과보다 더 많이 올라갈 수 있었습니다.

## 변경한 이벤트 흐름
이번 PR에서는 책임을 아래처럼 나눴습니다.

### 1. `ACC_EnemyCharacter::Die()`
- 실제 적 사망이 확정되는 지점입니다.
- 여기서만 `ReportActualDeathToEnemyManager()` 를 호출합니다.
- `bReportedActualDeath` 플래그로 **같은 적이 중복 보고되지 않도록** 막았습니다.

### 2. `ACC_EnemyManager`
- `UnregisterEnemy()` 는 이제 **정리 / 추적 해제 책임만** 가집니다.
- 새로 추가한 `ReportEnemyKilled()` / `OnEnemyKilled` 는 **실제 사망 이벤트 전용 흐름**입니다.
- 이미 추적에서 빠진 적이 사망 보고를 보내면 로그를 남기고 무시하도록 했습니다.

### 3. `ACC_CycleManager`
- 더 이상 `OnEnemyUnregistered` 를 듣지 않습니다.
- 이제는 `ACC_EnemyManager::OnEnemyKilled` 에만 바인딩됩니다.
- 그래서 사이클 킬 카운트는 **확정된 실제 사망 이벤트**에서만 증가합니다.
- 기존 사이클 완료 로직 자체는 그대로 유지했습니다.

## 리뷰 시 중점적으로 봐주실 부분
- `Source/CristalCube/Characters/CC_EnemyCharacter.cpp`
  - 실제 사망 보고가 `EndPlay()` 가 아니라 `Die()` 에서만 일어나도록 바뀌었습니다.
- `Source/CristalCube/CC_EnemyManager.cpp`
  - `UnregisterEnemy()` 와 실제 사망 이벤트가 분리되었습니다.
- `Source/CristalCube/CC_CycleManager.cpp`
  - 사이클 킬 집계가 cleanup 이벤트가 아니라 confirmed death 이벤트에만 반응하도록 바뀌었습니다.

## 테스트 / 검증 시나리오
### 1. 일반 전투 사망
1. 적을 스폰합니다.
2. 일반 공격/데미지 흐름으로 적을 처치합니다.
3. `CycleManager` 로그에 `Counted confirmed kill...` 이 출력되는지 확인합니다.
4. 현재 사이클 킬 진행도가 1 증가하는지 확인합니다.

### 2. 실제 사망 후 정리 단계
1. 적을 정상적으로 처치합니다.
2. 이후 `Destroy()` / `SetLifeSpan()` / `EndPlay()` 까지 진행되도록 둡니다.
3. 정리 단계에서 킬 카운트가 추가로 증가하지 않는지 확인합니다.

### 3. 실제 사망 없이 강제 제거
1. 적을 `Die()` 없이 강제로 제거하거나 레벨 정리 흐름에 포함시킵니다.
2. `EnemyManager` 에서는 unregister 처리가 되는지 확인합니다.
3. 사이클 킬 카운트는 증가하지 않는지 확인합니다.

### 4. 사이클 완료 회귀 확인
1. 현재 사이클의 마지막 필요 킬까지 도달시킵니다.
2. `OnCubeCleared` 가 정상적으로 한 번만 발생하는지 확인합니다.
3. 그 뒤 남은 적 정리 과정에서 킬 수가 추가로 올라가지 않는지 확인합니다.

## 로그로 확인할 수 있는 포인트
아래 로그로 실제 사망과 단순 정리를 구분해서 확인할 수 있습니다.
- `[ENEMY MANAGER] Confirmed enemy death: ...`
- `[ENEMY MANAGER] Unregistered enemy for cleanup: ...`
- `[CycleManager] Counted confirmed kill for ...`

리뷰나 플레이 테스트 시, 이 로그들을 보면 이벤트가 어떤 경로로 들어왔는지 빠르게 확인할 수 있습니다.

## 이번 브랜치에서 수행한 검증
- `Die`, `EndPlay`, manager unregister, cycle binding 흐름을 직접 점검했습니다.
- `git diff --check` 를 실행해서 diff 형식 이상 여부를 확인했습니다.

다만 현재 작업 환경에는 Unreal 빌드 툴이 없어, 로컬 컴파일/실행 검증까지는 진행하지 못했습니다.

## 후속 개선 아이디어
- `ACC_EnemyManager::Get()` 가 teardown 경로에서 새 인스턴스를 만들지 않도록, optional non-spawning 조회 경로를 두는 것도 고려할 수 있습니다.
- 실제 사망/강제 제거를 각각 자동화된 gameplay test 로 분리해 두면, 같은 문제가 다시 들어오는 것을 막기 좋습니다.
- 다른 시스템도 "실제 킬" 에 반응해야 한다면, unregister 대신 `OnEnemyKilled` 를 구독하도록 맞추는 편이 더 안전합니다.
