### PR TITLE
fix: 플레이어 무기 상태를 일관되게 정리

### DIFF
--- a/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
@@ -253,6 +253,9 @@ bool ACC_PlayerCharacter::EquipWeapon(ACC_Weapon* Weapon)
 	// Add to equipped weapons list
 	EquippedWeapons.Add(Weapon);
 
+	// The equipped list is authoritative. CurrentWeapon is only a selection within it.
+	SyncCurrentWeapon(CurrentWeapon ? CurrentWeapon : Weapon);
+
 	// Start auto-attack
 	StartWeaponAutoAttack(Weapon);
 
@@ -318,6 +321,8 @@ void ACC_PlayerCharacter::UnequipWeapon(ACC_Weapon* Weapon)
 	// Remove from list
 	EquippedWeapons.Remove(Weapon);
 
+	SyncCurrentWeapon();
+
 	// Cleanup weapon
 	Weapon->OnUnequipped();
 	Weapon->Destroy();
@@ -336,19 +341,48 @@ void ACC_PlayerCharacter::UnequipAllWeapons()
 		UnequipWeapon(Weapon);
 	}
 
+	SyncCurrentWeapon();
+
 	CC_LOG_PLAYER(Log, "Unequipped all weapons");
 }
 
 void ACC_PlayerCharacter::SwitchWeapon()
 {
+	if (EquippedWeapons.Num() == 0)
+	{
+		CurrentWeapon = nullptr;
+		CC_LOG_PLAYER(Warning, "Cannot switch weapon - no equipped weapons");
+		return;
+	}
 
+	if (EquippedWeapons.Num() == 1)
+	{
+		SyncCurrentWeapon(EquippedWeapons[0]);
+		CC_LOG_PLAYER(VeryVerbose, "Weapon switch skipped - only one equipped weapon");
+		return;
+	}
+
+	const int32 CurrentWeaponIndex = EquippedWeapons.IndexOfByKey(CurrentWeapon);
+	const int32 NextWeaponIndex = (CurrentWeaponIndex == INDEX_NONE)
+		? 0
+		: (CurrentWeaponIndex + 1) % EquippedWeapons.Num();
+
+	SyncCurrentWeapon(EquippedWeapons[NextWeaponIndex]);
+
+	CC_LOG_PLAYER(Log, "Switched current weapon to: %s", CC_ACTOR_NAME(CurrentWeapon));
 }
 
 void ACC_PlayerCharacter::PerformAttack()
 {
+	SyncCurrentWeapon();
+
 	if (CurrentWeapon && CurrentWeapon->CanAttack())
 	{
 		CurrentWeapon->Attack();
+	}
+	else if (!CurrentWeapon)
+	{
+		CC_LOG_PLAYER(VeryVerbose, "Manual attack skipped - no current weapon selected");
 	}
 }
 
@@ -403,11 +437,35 @@ ACC_Weapon* ACC_PlayerCharacter::CreateWeapon(TSubclassOf<ACC_Weapon> WeaponClas
 	return NewWeapon;
 }
 
+void ACC_PlayerCharacter::SyncCurrentWeapon(ACC_Weapon* PreferredWeapon)
+{
+	if (PreferredWeapon && EquippedWeapons.Contains(PreferredWeapon))
+	{
+		CurrentWeapon = PreferredWeapon;
+		return;
+	}
+
+	if (CurrentWeapon && EquippedWeapons.Contains(CurrentWeapon))
+	{
+		return;
+	}
+
+	CurrentWeapon = EquippedWeapons.Num() > 0
+		? EquippedWeapons[0]
+		: nullptr;
+}
+
 void ACC_PlayerCharacter::StartWeaponAutoAttack(ACC_Weapon* Weapon)
 {
 	if (!Weapon)
 	{
 		CC_LOG_PLAYER(Warning, "Cannot start auto-attack - weapon is null");
+		return;
+	}
+
+	if (WeaponAttackTimers.Contains(Weapon))
+	{
+		CC_LOG_PLAYER(VeryVerbose, "Auto-attack already active for weapon");
 		return;
 	}
 

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.h
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.h
@@ -82,10 +82,12 @@ protected:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon")
 	int32 StartingWeaponCount = 2;
 
-	// Current active weapon
+	// Selected weapon for manual attacks and single-weapon UI references.
+	// EquippedWeapons remains the authoritative set of owned/equipped weapons.
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon")
 	class ACC_Weapon* CurrentWeapon;
 
+	// All equipped weapons. Each equipped weapon runs its own auto-attack loop.
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Player|Weapons")
 	TArray<ACC_Weapon*> EquippedWeapons;
 
@@ -99,6 +101,8 @@ protected:
 
 	UPROPERTY()
 	TMap<ACC_Weapon*, FTimerHandle> WeaponAttackTimers;
+
+	void SyncCurrentWeapon(ACC_Weapon* PreferredWeapon = nullptr);
 
 public:
 


### PR DESCRIPTION
## 요약
이번 PR은 플레이어의 무기 상태를 이해하기 어렵게 만들던 `CurrentWeapon`, `EquippedWeapons`, 자동 공격, 수동 공격 사이의 역할을 정리해서, 코드상 상태가 서로 모순되지 않도록 맞춘 변경입니다.

현재 코드베이스는 사실상 "장착한 모든 무기가 자동 공격한다" 는 방향으로 이미 동작하고 있었습니다. 그런데 동시에 `CurrentWeapon` 이라는 단일 무기 개념도 남아 있었고, 이 값이 실제 장착 흐름에서 제대로 세팅되지 않아 수동 공격 경로와 자동 공격 경로가 서로 다른 상태 모델을 보고 있었습니다.

## 왜 기존 상태가 혼란스러웠는가
- `EquippedWeapons` 에 들어간 무기들은 장착 즉시 각각 자동 공격 타이머를 시작하고 있었습니다.
- 반면 수동 공격은 `CurrentWeapon` 만 사용하고 있었는데, 이 값은 장착 시점에 사실상 설정되지 않았습니다.
- `SwitchWeapon()` 도 비어 있어서, "현재 무기" 라는 개념이 API 상으로만 존재하고 실제 동작은 정의되지 않은 상태였습니다.
- 그 결과 플레이어가 무기를 장착하고 있어도, 수동 공격은 아무 일도 하지 않을 수 있었고, 자동 공격과 수동 공격이 서로 다른 기준을 따르는 구조가 되어 있었습니다.

## 이번 PR에서 정리한 상태 모델
이번 변경에서는 과한 재설계 대신, 현재 코드의 실제 의도에 맞춰 아래처럼 역할을 분리했습니다.

- `EquippedWeapons`
플레이어가 현재 장착한 무기의 권위 있는 목록입니다. 무기 보유/장착 여부는 이 배열이 기준입니다.

- `CurrentWeapon`
장착된 무기들 중에서 "수동 공격" 과 "단일 선택 UI" 가 참조하는 선택된 무기입니다. 더 이상 별도의 독립 상태가 아니라, 항상 `EquippedWeapons` 안에 있는 무기이거나 아무 무기도 없을 때만 `nullptr` 입니다.

- 자동 공격
기존 의도를 유지해서, 장착된 각 무기가 자신의 타이머로 자동 공격합니다.

- 수동 공격
`CurrentWeapon` 을 기준으로 수행합니다. 단, 공격 전에 현재 선택이 유효한지 다시 맞춰서, 장착 무기와 어긋난 포인터를 잡고 있지 않도록 했습니다.

## 코드에서 어디를 보면 이해가 빠른가
먼저 아래 두 파일만 보시면 전체 맥락이 바로 잡힙니다.

- `Source/CristalCube/Characters/CC_PlayerCharacter.h`
- `Source/CristalCube/Characters/CC_PlayerCharacter.cpp`

특히 아래 지점을 순서대로 보시면 됩니다.

- `EquipWeapon()`
무기를 장착한 뒤 `EquippedWeapons` 에 추가하고, `CurrentWeapon` 이 유효한 선택 상태를 유지하도록 동기화합니다.

- `UnequipWeapon()` / `UnequipAllWeapons()`
무기 제거 후에도 `CurrentWeapon` 이 항상 남아 있는 장착 무기 중 하나를 가리키거나, 남은 무기가 없으면 `nullptr` 이 되도록 정리합니다.

- `SwitchWeapon()`
이전에는 비어 있던 함수를 실제 순환 로직으로 구현해서, 장착된 무기 목록 안에서 현재 선택을 돌릴 수 있게 했습니다.

- `PerformAttack()`
수동 공격 전에 현재 선택 상태를 보정해서, 선택 무기가 장착 목록과 어긋난 상태로 남지 않도록 했습니다.

- `SyncCurrentWeapon()`
이번 PR의 핵심 헬퍼입니다. "현재 무기는 항상 장착 목록 안에 있어야 한다" 는 규칙을 한 곳에서 관리합니다.

- `StartWeaponAutoAttack()`
같은 무기에 대해 자동 공격 타이머가 중복 등록되지 않도록 방어 로직을 추가했습니다.

## 플레이어 기준 기대 동작
플레이어 입장에서는 아래처럼 이해하면 됩니다.

- 무기를 하나 이상 장착하고 있다면, 수동 공격에서 참조할 "현재 무기" 가 항상 일관되게 존재합니다.
- 여러 무기를 장착하면, 기존처럼 각 무기가 자동 공격합니다.
- 수동 공격은 이제 실제로 선택된 현재 무기를 사용합니다.
- 무기 전환 시에는 장착된 무기들 사이를 순서대로 순환합니다.
- 현재 무기를 해제해도 남아 있는 다른 장비 중 하나로 자연스럽게 넘어가고, 모든 무기를 해제하면 현재 무기도 깨끗하게 비워집니다.

## 후속 확장 포인트
이번 정리는 현재 코드의 혼선을 줄이는 데 집중했고, 이후 확장도 쉽게 만들었습니다.

- HUD 에서 현재 선택 무기를 표시하고 싶다면 `CurrentWeapon` 을 그대로 신뢰해도 됩니다.
- 나중에 "완전 자동 공격형" 혹은 "수동 선택 중심형" 으로 더 분명하게 시스템을 갈라가고 싶다면, 지금은 상태 경계가 분명해져 있어서 정리 지점이 명확합니다.
- 장착 순서와 선택 순서를 분리하고 싶다면 `SyncCurrentWeapon()` 과 `SwitchWeapon()` 이 주요 확장 지점이 됩니다.

## 검증
- `git diff --check` 확인
- 코드 레벨에서 장착 / 해제 / 전체 해제 / 수동 공격 / 무기 전환 흐름을 기준으로 상태 일관성 점검

현재 환경에서는 Unreal 빌드 툴체인을 찾지 못해서 실제 엔진 빌드는 수행하지 못했습니다.
