### PR TITLE
feat: 사이클 적 배율을 실제 스폰 적 스탯에 적용

### DIFF
--- a/Source/CristalCube/CC_CycleManager.cpp
+++ b/Source/CristalCube/CC_CycleManager.cpp
@@ -99,7 +99,9 @@ void ACC_CycleManager::StartCycle(int32 CycleNumber)
     KillsThisCycle = 0;
     bCycleActive = true;
 
-    FCycleConfig Config = GetCurrentCycleConfig();
+    GetWorldTimerManager().ClearTimer(TimeLimitHandle);
+
+    const FCycleConfig Config = GetCurrentCycleConfig();
 
     // 제한 시간 설정 (0이면 킬 수 기반)
     if (Config.TimeLimit > 0.f)
@@ -113,8 +115,13 @@ void ACC_CycleManager::StartCycle(int32 CycleNumber)
     OnCycleStarted.Broadcast(CurrentCycle);
     OnKillCountUpdated.Broadcast(0, GetKillsRequired());
 
-    UE_LOG(LogTemp, Warning, TEXT("[CycleManager] Cycle %d started — KillsRequired: %d, MaxEnemies: %d"),
-        CurrentCycle, GetKillsRequired(), Config.MaxEnemies);
+    UE_LOG(LogTemp, Warning,
+        TEXT("[CycleManager] Cycle %d started — KillsRequired: %d, MaxEnemies: %d, Damage x%.2f, Speed x%.2f"),
+        CurrentCycle,
+        GetKillsRequired(),
+        Config.MaxEnemies,
+        Config.EnemyDamageMultiplier,
+        Config.EnemySpeedMultiplier);
 }
 
 void ACC_CycleManager::CheckCycleCompletion()
@@ -147,7 +154,18 @@ void ACC_CycleManager::OnTimeLimitReached()
 
 FCycleConfig ACC_CycleManager::GetCurrentCycleConfig() const
 {
-    int32 Index = CurrentCycle - 1;
+    return GetCycleConfigForCycle(CurrentCycle);
+}
+
+FCycleConfig ACC_CycleManager::GetCycleConfigForCycle(int32 CycleNumber) const
+{
+    if (CycleConfigs.IsEmpty())
+    {
+        return FCycleConfig();
+    }
+
+    const int32 SafeCycleNumber = FMath::Max(CycleNumber, 1);
+    const int32 Index = SafeCycleNumber - 1;
 
     if (CycleConfigs.IsValidIndex(Index))
     {
@@ -156,11 +174,13 @@ FCycleConfig ACC_CycleManager::GetCurrentCycleConfig() const
 
     // 배열 초과 시 마지막 항목에 누적 배율 적용
     FCycleConfig Last = CycleConfigs.Last();
-    int32 Overflow = Index - (CycleConfigs.Num() - 1);
+    const int32 Overflow = Index - (CycleConfigs.Num() - 1);
 
     Last.KillsRequired += KillsIncreasePerCycle * Overflow;
     Last.EnemyDamageMultiplier += DamageMultiplierIncreasePerCycle * Overflow;
-    Last.EnemySpeedMultiplier = FMath::Min(Last.EnemySpeedMultiplier + 0.05f * Overflow, 2.0f);
+    Last.EnemySpeedMultiplier = FMath::Min(
+        Last.EnemySpeedMultiplier + SpeedMultiplierIncreasePerCycle * Overflow,
+        2.0f);
 
     return Last;
 }

--- a/Source/CristalCube/CC_CycleManager.h
+++ b/Source/CristalCube/CC_CycleManager.h
@@ -95,6 +95,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cycle Config")
     float DamageMultiplierIncreasePerCycle = 0.2f;
 
+    /** 배열 초과 시 사이클마다 누적되는 적 이동속도 배율 증가 */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Cycle Config")
+    float SpeedMultiplierIncreasePerCycle = 0.05f;
+
     // ========== 런타임 상태 ==========
 
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "State")
@@ -133,6 +137,9 @@ public:
     /** 현재 사이클 Config 반환 */
     UFUNCTION(BlueprintPure, Category = "Cycle")
     FCycleConfig GetCurrentCycleConfig() const;
+
+    /** 특정 사이클의 Config 반환 */
+    FCycleConfig GetCycleConfigForCycle(int32 CycleNumber) const;
 
     /** 킬 진행도 (0.0 ~ 1.0) */
     UFUNCTION(BlueprintPure, Category = "Cycle")

--- a/Source/CristalCube/CC_EnemySpawner.cpp
+++ b/Source/CristalCube/CC_EnemySpawner.cpp
@@ -5,6 +5,7 @@
 #include "Characters/CC_EnemyCharacter.h"
 #include "Characters/CC_PlayerCharacter.h"
 #include "Gameplay/CC_Cube.h"
+#include "CC_MainGameMode.h"
 #include "CC_LogHelper.h"
 #include "TimerManager.h"
 #include "Kismet/GameplayStatics.h"
@@ -186,33 +187,47 @@ ACC_EnemyCharacter* ACC_EnemySpawner::SpawnSingleEnemy(const FVector& Location)
     }
 
     FRotator SpawnRotation = FRotator::ZeroRotator;
+    const FTransform SpawnTransform(SpawnRotation, Location);
 
-    FActorSpawnParameters SpawnParams;
-    SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn;
-
-    ACC_EnemyCharacter* NewEnemy = GetWorld()->SpawnActor<ACC_EnemyCharacter>(
+    ACC_EnemyCharacter* NewEnemy = GetWorld()->SpawnActorDeferred<ACC_EnemyCharacter>(
         EnemyClass,
-        Location,
-        SpawnRotation,
-        SpawnParams
+        SpawnTransform,
+        this,
+        nullptr,
+        ESpawnActorCollisionHandlingMethod::AdjustIfPossibleButAlwaysSpawn
     );
 
-    if (NewEnemy)
-    {
-        if (OwnerCube)
-        {
-            OwnerCube->RegisterActor(NewEnemy);
-            CC_LOG_SPAWNER(VeryVerbose, TEXT("Registered enemy with Cube (%d, %d)"),
-                OwnerCube->CubeCoordinate.X, OwnerCube->CubeCoordinate.Y);
-        }
-
-        CC_LOG_SPAWNER(VeryVerbose, TEXT("Spawned enemy at (%.0f, %.0f, %.0f)"),
-            Location.X, Location.Y, Location.Z);
-    }
-    else
+    if (!NewEnemy)
     {
         CC_LOG_SPAWNER(Warning, TEXT("Failed to spawn enemy at location"));
+        return nullptr;
     }
+
+    float DamageMultiplier = 1.0f;
+    float SpeedMultiplier = 1.0f;
+
+    if (ACC_MainGameMode* MainGameMode = Cast<ACC_MainGameMode>(UGameplayStatics::GetGameMode(this)))
+    {
+        if (ACC_CycleManager* CycleManager = MainGameMode->GetCycleManager())
+        {
+            const FCycleConfig CycleConfig = CycleManager->GetCurrentCycleConfig();
+            DamageMultiplier = CycleConfig.EnemyDamageMultiplier;
+            SpeedMultiplier = CycleConfig.EnemySpeedMultiplier;
+        }
+    }
+
+    NewEnemy->ApplyCycleStatScaling(DamageMultiplier, SpeedMultiplier);
+    NewEnemy->FinishSpawning(SpawnTransform);
+
+    if (OwnerCube)
+    {
+        OwnerCube->RegisterActor(NewEnemy);
+        CC_LOG_SPAWNER(VeryVerbose, TEXT("Registered enemy with Cube (%d, %d)"),
+            OwnerCube->CubeCoordinate.X, OwnerCube->CubeCoordinate.Y);
+    }
+
+    CC_LOG_SPAWNER(VeryVerbose, TEXT("Spawned enemy at (%.0f, %.0f, %.0f)"),
+        Location.X, Location.Y, Location.Z);
 
     return NewEnemy;
 }

--- a/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
@@ -15,6 +15,8 @@
 #include "../CC_EnemyManager.h"
 #include "../CC_AIManager.h"
 #include "../CC_EnemyAIController.h"
+#include "../CC_CycleManager.h"
+#include "../CC_MainGameMode.h"
 #include "../Gameplay/CC_ExperienceGem.h"
 
 ACC_EnemyCharacter::ACC_EnemyCharacter()
@@ -70,9 +72,75 @@ ACC_EnemyCharacter::ACC_EnemyCharacter()
 	bIsBoss = false;
 }
 
+void ACC_EnemyCharacter::CacheBaseStatsIfNeeded()
+{
+	if (bBaseStatsCached)
+	{
+		return;
+	}
+
+	BaseMoveSpeed = MoveSpeed;
+	BaseContactDamage = ContactDamage;
+	BaseEnemyStats = EnemyStats;
+	bBaseStatsCached = true;
+}
+
+void ACC_EnemyCharacter::ApplyCycleStatScaling(float DamageMultiplier, float SpeedMultiplier)
+{
+	CacheBaseStatsIfNeeded();
+
+	AppliedDamageMultiplier = FMath::Max(DamageMultiplier, 0.0f);
+	AppliedSpeedMultiplier = FMath::Max(SpeedMultiplier, 0.0f);
+
+	EnemyStats = BaseEnemyStats;
+	EnemyStats.AttackDamage = BaseEnemyStats.AttackDamage * AppliedDamageMultiplier;
+	ContactDamage = BaseContactDamage * AppliedDamageMultiplier;
+	MoveSpeed = BaseMoveSpeed * AppliedSpeedMultiplier;
+
+	if (UCharacterMovementComponent* Movement = GetCharacterMovement())
+	{
+		Movement->MaxWalkSpeed = MoveSpeed;
+	}
+
+	bCycleStatScalingApplied = true;
+
+	UE_LOG(LogTemp, Log,
+		TEXT("[ENEMY] %s cycle scaling applied - Damage x%.2f, Speed x%.2f (Attack: %.1f, Contact: %.1f, MoveSpeed: %.1f)"),
+		*GetName(),
+		AppliedDamageMultiplier,
+		AppliedSpeedMultiplier,
+		EnemyStats.AttackDamage,
+		ContactDamage,
+		MoveSpeed);
+}
+
+void ACC_EnemyCharacter::ApplyCurrentCycleStatScalingFallback()
+{
+	float DamageMultiplier = 1.0f;
+	float SpeedMultiplier = 1.0f;
+
+	if (ACC_MainGameMode* MainGameMode = Cast<ACC_MainGameMode>(UGameplayStatics::GetGameMode(this)))
+	{
+		if (ACC_CycleManager* CycleManager = MainGameMode->GetCycleManager())
+		{
+			const FCycleConfig CycleConfig = CycleManager->GetCurrentCycleConfig();
+			DamageMultiplier = CycleConfig.EnemyDamageMultiplier;
+			SpeedMultiplier = CycleConfig.EnemySpeedMultiplier;
+		}
+	}
+
+	ApplyCycleStatScaling(DamageMultiplier, SpeedMultiplier);
+}
+
 void ACC_EnemyCharacter::BeginPlay()
 {
 	Super::BeginPlay();
+
+	CacheBaseStatsIfNeeded();
+	if (!bCycleStatScalingApplied)
+	{
+		ApplyCurrentCycleStatScalingFallback();
+	}
 
 	if (!GetController())
 	{
@@ -91,8 +159,8 @@ void ACC_EnemyCharacter::BeginPlay()
 		Capsule->OnComponentBeginOverlap.AddDynamic(this, &ACC_EnemyCharacter::OnOverlapBegin);
 	}
 
-	CC_LOG_ENEMY(Warning, TEXT("Spawned enemy: %s (HP: %.0f, Damage: %.0f)"),
-		*EnemyType, MaxHealth, ContactDamage);
+	CC_LOG_ENEMY(Warning, TEXT("Spawned enemy: %s (HP: %.0f, Attack: %.1f, Contact: %.1f, Speed: %.1f)"),
+		*EnemyType, MaxHealth, EnemyStats.AttackDamage, ContactDamage, MoveSpeed);
 
 	if (AttackRangeSphere)
 	{
@@ -115,7 +183,7 @@ void ACC_EnemyCharacter::BeginPlay()
 	else
 	{
 		UE_LOG(LogTemp, Warning, TEXT("AI Manager not found, using fallback AI for: %s"), *GetName());
-		// Fallback: ±âÁ¸ ¹æ½ÄÀ¸·Î µ¿ÀÛ (AI Manager ¾ø¾îµµ °ÔÀÓ ÁøÇà °¡´É)
+		// Fallback: Â±Ã¢ÃÂ¸ Â¹Ã¦Â½Ã„Ã€Â¸Â·Ã ÂµÂ¿Ã€Ã› (AI Manager Â¾Ã¸Â¾Ã®ÂµÂµ Â°Ã”Ã€Ã“ ÃÃ¸Ã‡Ã  Â°Â¡Â´Ã‰)
 	}
 
 	if (USkeletalMeshComponent* SkeletalMesh = GetMesh())
@@ -236,7 +304,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 	{
 		case EAttackHitType::Point:
 		{
-			// ´ÜÀÏ Å¸°Ù¸¸
+			// Â´ÃœÃ€Ã Ã…Â¸Â°Ã™Â¸Â¸
 			if (!TargetPlayer) return false;
 
 			float Distance = FVector::Dist(Start, TargetPlayer->GetActorLocation());
@@ -249,7 +317,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 
 		case EAttackHitType::Sphere:
 		{
-			// 360µµ ¿øÇü ¹üÀ§
+			// 360ÂµÂµ Â¿Ã¸Ã‡Ã¼ Â¹Ã¼Ã€Â§
 			TArray<FOverlapResult> Overlaps;
 			FCollisionQueryParams Params;
 			Params.AddIgnoredActor(this);
@@ -276,16 +344,16 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 
 		case EAttackHitType::Line:
 		{
-			// È¾º£±â: ÁÂ¿ì·Î ³Ğ°í Àü¹æÀ¸·Î ¾ãÀº Box
+			// ÃˆÂ¾ÂºÂ£Â±Ã¢: ÃÃ‚Â¿Ã¬Â·Ã Â³ÃÂ°Ã­ Ã€Ã¼Â¹Ã¦Ã€Â¸Â·Ã Â¾Ã£Ã€Âº Box
 			FVector HitStart = Start;
 			FVector HitEnd = Start + (Forward * HitData.Range);
 			FVector HitCenter = (HitStart + HitEnd) * 0.5f;
 
-			// Box Å©±â: X=¾ã°Ô, Y=³Ğ°Ô!
+			// Box Ã…Â©Â±Ã¢: X=Â¾Ã£Â°Ã”, Y=Â³ÃÂ°Ã”!
 			FVector BoxExtent(
-				HitData.Thickness * 0.5f,  // Àü¹æ µÎ²² (¾ã°Ô)
-				HitData.Width * 1.f,      // ÁÂ¿ì Æø (³Ğ°Ô!)
-				HitData.Height * 0.5f      // »óÇÏ ³ôÀÌ
+				HitData.Thickness * 0.5f,  // Ã€Ã¼Â¹Ã¦ ÂµÃÂ²Â² (Â¾Ã£Â°Ã”)
+				HitData.Width * 1.f,      // ÃÃ‚Â¿Ã¬ Ã†Ã¸ (Â³ÃÂ°Ã”!)
+				HitData.Height * 0.5f      // Â»Ã³Ã‡Ã Â³Ã´Ã€ÃŒ
 			);
 
 			TArray<FHitResult> HitResults;
@@ -315,7 +383,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 
 		case EAttackHitType::Box:
 		{
-			// Àü¹æ »ç°¢Çü
+			// Ã€Ã¼Â¹Ã¦ Â»Ã§Â°Â¢Ã‡Ã¼
 			FVector HitStart = Start;
 			FVector HitEnd = Start + (Forward * HitData.Range);
 
@@ -352,12 +420,12 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 
 		case EAttackHitType::Cone:
 		{
-			// ºÎÃ¤²Ã
+			// ÂºÃÃƒÂ¤Â²Ãƒ
 			TArray<FOverlapResult> Overlaps;
 			FCollisionQueryParams Params;
 			Params.AddIgnoredActor(this);
 
-			// ÀÏ´Ü ±¸Ã¼·Î ÈÄº¸ Ã£±â
+			// Ã€ÃÂ´Ãœ Â±Â¸ÃƒÂ¼Â·Ã ÃˆÃ„ÂºÂ¸ ÃƒÂ£Â±Ã¢
 			GetWorld()->OverlapMultiByChannel(
 				Overlaps,
 				Start,
@@ -367,7 +435,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 				Params
 			);
 
-			// °¢µµ ÇÊÅÍ¸µ
+			// Â°Â¢ÂµÂµ Ã‡ÃŠÃ…ÃÂ¸Âµ
 			for (const FOverlapResult& Overlap : Overlaps)
 			{
 				if (ACC_PlayerCharacter* Target = Cast<ACC_PlayerCharacter>(Overlap.GetActor()))
@@ -389,7 +457,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 
 		case EAttackHitType::Capsule:
 		{
-			// ±ä ¿øÅë
+			// Â±Ã¤ Â¿Ã¸Ã…Ã«
 			FVector HitStart = Start;
 			FVector HitEnd = Start + (Forward * HitData.Range);
 
@@ -419,7 +487,7 @@ bool ACC_EnemyCharacter::PerformAttackHit(const FAttackHitData& HitData, TArray<
 		}
 	}
 
-	// µğ¹ö±× ½Ã°¢È­
+	// ÂµÃ°Â¹Ã¶Â±Ã— Â½ÃƒÂ°Â¢ÃˆÂ­
 	if (bShowAttackDebug)
 	{
 		DrawAttackDebug(HitData, OutHitTargets.Num() > 0);

--- a/Source/CristalCube/Characters/CC_EnemyCharacter.h
+++ b/Source/CristalCube/Characters/CC_EnemyCharacter.h
@@ -26,6 +26,9 @@ public:
 
 	virtual void Tick(float DeltaTime) override;
 
+	UFUNCTION(BlueprintCallable, Category = "Enemy|Stats")
+	void ApplyCycleStatScaling(float DamageMultiplier, float SpeedMultiplier);
+
 protected:
 
 	// Target player reference
@@ -193,6 +196,19 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "Combat")
 	float GetAttackCooldownPercent() const;
+
+private:
+
+	void CacheBaseStatsIfNeeded();
+	void ApplyCurrentCycleStatScalingFallback();
+
+	bool bBaseStatsCached = false;
+	bool bCycleStatScalingApplied = false;
+	float BaseMoveSpeed = 0.0f;
+	float BaseContactDamage = 0.0f;
+	FCristalCubeEnemyStats BaseEnemyStats;
+	float AppliedDamageMultiplier = 1.0f;
+	float AppliedSpeedMultiplier = 1.0f;
 
 protected:
 	


### PR DESCRIPTION
## 개요
이번 PR은 `FCycleConfig` 에 정의되어 있던 사이클별 적 공격력 배율(`EnemyDamageMultiplier`)과 이동속도 배율(`EnemySpeedMultiplier`)이 실제 게임플레이에 반영되도록 연결합니다.

기존에는 사이클 데이터에 배율 값이 존재해도, 새로 스폰된 적의 실제 스탯에는 적용되지 않아 사이클 progression 이 의도한 만큼 전투 난이도에 반영되지 않았습니다. 이 변경으로 각 사이클에서 새로 생성되는 적이 해당 사이클의 난이도 설정을 기준으로 공격력과 이동속도를 갖도록 정리했습니다.

## 왜 중요한가
사이클 루프는 이 게임의 핵심 진행 구조인데, 적 배율이 실제 전투에 연결되지 않으면 플레이어가 다음 사이클로 넘어가도 위협 수준이 체감되지 않습니다.

즉,
- 사이클은 올라가는데 적은 사실상 같은 성능으로 등장하고,
- Cube Clear 이후의 긴장감과 보상 구조가 약해지며,
- 게임 루프 완성도가 떨어집니다.

이번 작업은 사이클 데이터와 실제 적 스탯을 연결해서, Cube Clear 이후의 다음 사이클이 플레이 감각상으로도 분명히 달라지게 만드는 데 목적이 있습니다.

## 변경 내용
### 1. 사이클 설정 조회 구조 정리
- `ACC_CycleManager` 에서 현재 사이클 설정 조회를 `GetCycleConfigForCycle()` 로 분리했습니다.
- 현재 사이클 조회(`GetCurrentCycleConfig()`)도 이 경로를 사용하도록 정리했습니다.
- 배열 범위를 넘는 이후 사이클에서도 공격력/이동속도 증가 규칙이 한 곳에서 계산되도록 맞췄습니다.
- 속도 증가량도 `SpeedMultiplierIncreasePerCycle` 로 분리해서 이후 체력 등 다른 난이도 요소를 붙일 때 같은 패턴으로 확장하기 쉽게 했습니다.

### 2. 적 기본 스탯과 적용 스탯 분리
- `ACC_EnemyCharacter` 에 기본 이동속도, 기본 접촉 데미지, 기본 공격 데미지를 캐시하는 구조를 추가했습니다.
- 새 함수 `ApplyCycleStatScaling()` 에서 항상 “기본 스탯 기준”으로 최종 값을 다시 계산하도록 했습니다.
- 이 방식으로 같은 적에게 배율 적용 함수가 다시 호출되더라도 값이 누적 곱으로 계속 커지지 않도록 했습니다.

실제 적용 방식은 다음과 같습니다.
- 공격력 배율: `EnemyStats.AttackDamage`, `ContactDamage` 에 적용
- 이동속도 배율: `MoveSpeed`, `CharacterMovement->MaxWalkSpeed` 에 적용

### 3. 스폰 시점에 현재 사이클 배율 적용
- `ACC_EnemySpawner` 의 적 생성 흐름을 `SpawnActorDeferred -> 배율 적용 -> FinishSpawning` 순서로 변경했습니다.
- 이로 인해 적의 `BeginPlay()` 이전에 현재 사이클 배율이 반영됩니다.
- 따라서 새 사이클에서 스폰된 적은 즉시 해당 사이클 설정을 반영한 상태로 등장합니다.

### 4. 비스포너 경로에 대한 안전장치 추가
- 혹시 다른 경로로 적이 생성되는 경우를 대비해, `ACC_EnemyCharacter::BeginPlay()` 에 현재 사이클을 읽어 적용하는 fallback 경로도 남겨두었습니다.
- 기본 경로는 스포너에서 주입하는 방식이지만, 예상 밖 생성 경로에서도 배율이 빠지지 않도록 했습니다.

## 리뷰어가 집중해서 볼 포인트
- 적 스탯 적용 시점이 `FinishSpawning()` 이전인 현재 구조가 의도에 맞는지
- 기본 스탯 캐시 방식이 중복 적용/누적 적용 방지에 충분한지
- “사이클이 바뀐 뒤 새로 스폰된 적만 새 배율을 받는다”는 동작이 현재 게임 디자인 의도와 일치하는지
- 추후 체력 배율 등 다른 난이도 요소를 같은 패턴으로 확장하기에 구조가 무리가 없는지

## 검증 내용
### 정적 확인
- `git diff --check`

### 수동 플레이 검증 시나리오
1. 사이클 1 시작 후 스폰된 적이 기준 공격력/이동속도로 동작하는지 확인
2. Cube Clear 이후 다음 사이클 진입 후, 새로 스폰된 적이 이전 사이클보다 더 빠르게 이동하고 더 강한 피해를 주는지 확인
3. 다음 사이클로 다시 넘어간 뒤에도 새 적만 새 배율을 반영하고, 기존 생존 적에게 값이 중복 누적되지 않는지 확인
4. 스포너 외 경로로 적이 생성되는 케이스가 있다면, `BeginPlay()` fallback 으로 현재 사이클 배율이 반영되는지 확인

## 이번 PR에서 하지 않은 것
- 배율 수치 자체의 밸런싱 조정은 이번 작업 범위에 포함하지 않았습니다.
- 체력 배율, 추가 난이도 요소, 보스 전용 배율 같은 확장은 이번 PR에서 넣지 않았습니다.
- 다만 이번 구조는 이후 체력이나 기타 스탯을 같은 방식으로 확장할 수 있도록 기본/적용 스탯 분리를 먼저 해둔 상태입니다.
