### PR TITLE
feat: 사이클 난이도를 적 스포너에 실제 연결

### DIFF
--- a/Source/CristalCube/CC_CycleManager.cpp
+++ b/Source/CristalCube/CC_CycleManager.cpp
@@ -2,7 +2,9 @@
 
 
 #include "CC_CycleManager.h"
+#include "CC_EnemySpawner.h"
 #include "CC_EnemyManager.h"
+#include "Kismet/GameplayStatics.h"
 #include "TimerManager.h"
 
 // Sets default values
@@ -101,6 +103,8 @@ void ACC_CycleManager::StartCycle(int32 CycleNumber)
 
     FCycleConfig Config = GetCurrentCycleConfig();
 
+    GetWorldTimerManager().ClearTimer(TimeLimitHandle);
+
     // 제한 시간 설정 (0이면 킬 수 기반)
     if (Config.TimeLimit > 0.f)
     {
@@ -110,11 +114,14 @@ void ACC_CycleManager::StartCycle(int32 CycleNumber)
             Config.TimeLimit, false);
     }
 
+    ApplyCycleConfigToSpawners(Config);
+
     OnCycleStarted.Broadcast(CurrentCycle);
     OnKillCountUpdated.Broadcast(0, GetKillsRequired());
 
-    UE_LOG(LogTemp, Warning, TEXT("[CycleManager] Cycle %d started — KillsRequired: %d, MaxEnemies: %d"),
-        CurrentCycle, GetKillsRequired(), Config.MaxEnemies);
+    UE_LOG(LogTemp, Warning,
+        TEXT("[CycleManager] Cycle %d started — KillsRequired: %d, MaxEnemies: %d, SpawnInterval: %.2f"),
+        CurrentCycle, GetKillsRequired(), Config.MaxEnemies, Config.SpawnInterval);
 }
 
 void ACC_CycleManager::CheckCycleCompletion()
@@ -139,6 +146,30 @@ void ACC_CycleManager::OnTimeLimitReached()
     UE_LOG(LogTemp, Warning, TEXT("[CycleManager] Cycle %d — Time limit reached"), CurrentCycle);
 
     OnCubeCleared.Broadcast(CurrentCycle);
+}
+
+void ACC_CycleManager::ApplyCycleConfigToSpawners(const FCycleConfig& Config)
+{
+    TArray<AActor*> FoundSpawners;
+    UGameplayStatics::GetAllActorsOfClass(GetWorld(), ACC_EnemySpawner::StaticClass(), FoundSpawners);
+
+    int32 AppliedSpawnerCount = 0;
+
+    for (AActor* SpawnerActor : FoundSpawners)
+    {
+        ACC_EnemySpawner* Spawner = Cast<ACC_EnemySpawner>(SpawnerActor);
+        if (!Spawner)
+        {
+            continue;
+        }
+
+        Spawner->ApplyCycleConfig(Config);
+        ++AppliedSpawnerCount;
+    }
+
+    UE_LOG(LogTemp, Log,
+        TEXT("[CycleManager] Applied cycle %d spawn difficulty to %d spawner(s)."),
+        CurrentCycle, AppliedSpawnerCount);
 }
 
 // ============================================================

--- a/Source/CristalCube/CC_CycleManager.h
+++ b/Source/CristalCube/CC_CycleManager.h
@@ -147,10 +147,14 @@ public:
     UFUNCTION(BlueprintPure, Category = "Cycle")
     int32 GetKillsThisCycle() const { return KillsThisCycle; }
 
+    UFUNCTION(BlueprintPure, Category = "Cycle")
+    bool IsCycleActive() const { return bCycleActive; }
+
 private:
 
     void StartCycle(int32 CycleNumber);
     void CheckCycleCompletion();
+    void ApplyCycleConfigToSpawners(const FCycleConfig& Config);
 
     /** 적 처치 시 호출 (EnemyCharacter 사망 시 연결) */
     UFUNCTION(BlueprintCallable, Category = "Cycle")

--- a/Source/CristalCube/CC_EnemySpawner.cpp
+++ b/Source/CristalCube/CC_EnemySpawner.cpp
@@ -2,10 +2,12 @@
 
 
 #include "CC_EnemySpawner.h"
+#include "CC_CycleManager.h"
 #include "Characters/CC_EnemyCharacter.h"
 #include "Characters/CC_PlayerCharacter.h"
 #include "Gameplay/CC_Cube.h"
 #include "CC_LogHelper.h"
+#include "EngineUtils.h"
 #include "TimerManager.h"
 #include "Kismet/GameplayStatics.h"
 
@@ -44,6 +46,7 @@ void ACC_EnemySpawner::BeginPlay()
     Super::BeginPlay();
 
     FindPlayer();
+    SyncWithActiveCycle();
 
     if (!EnemyClass)
     {
@@ -103,8 +106,20 @@ void ACC_EnemySpawner::StartSpawning()
         return;
     }
 
+    SyncWithActiveCycle();
+
     bIsSpawning = true;
-    CurrentSpawnInterval = SpawnInterval;
+
+    if (bIncreaseSpawnRate)
+    {
+        const float MinutesPlayed = GameTime / 60.0f;
+        const float IntervalDecrease = MinutesPlayed * SpawnIntervalDecreasePerMinute;
+        CurrentSpawnInterval = FMath::Max(SpawnInterval - IntervalDecrease, MinSpawnInterval);
+    }
+    else
+    {
+        CurrentSpawnInterval = SpawnInterval;
+    }
 
     // Set up repeating timer
     GetWorld()->GetTimerManager().SetTimer(
@@ -175,6 +190,43 @@ void ACC_EnemySpawner::SpawnEnemies()
     {
         CC_LOG_SPAWNER(Log, TEXT("Spawned %d enemies (Total: %d/%d, Interval: %.2fs)"),
             SuccessfulSpawns, GetAliveEnemyCount(), MaxEnemies, CurrentSpawnInterval);
+    }
+}
+
+void ACC_EnemySpawner::ApplyCycleConfig(const FCycleConfig& CycleConfig)
+{
+    const float PreviousSpawnInterval = SpawnInterval;
+    const int32 PreviousMaxEnemies = MaxEnemies;
+
+    SpawnInterval = FMath::Max(CycleConfig.SpawnInterval, KINDA_SMALL_NUMBER);
+    MaxEnemies = FMath::Max(CycleConfig.MaxEnemies, 0);
+
+    if (bIncreaseSpawnRate)
+    {
+        const float MinutesPlayed = GameTime / 60.0f;
+        const float IntervalDecrease = MinutesPlayed * SpawnIntervalDecreasePerMinute;
+        CurrentSpawnInterval = FMath::Max(SpawnInterval - IntervalDecrease, MinSpawnInterval);
+    }
+    else
+    {
+        CurrentSpawnInterval = SpawnInterval;
+    }
+
+    const bool bSpawnIntervalChanged = !FMath::IsNearlyEqual(PreviousSpawnInterval, SpawnInterval);
+    const bool bMaxEnemiesChanged = PreviousMaxEnemies != MaxEnemies;
+
+    if (bIsSpawning && bSpawnIntervalChanged)
+    {
+        RefreshSpawnTimer();
+    }
+
+    if (bSpawnIntervalChanged || bMaxEnemiesChanged)
+    {
+        CC_LOG_SPAWNER(Log,
+            TEXT("Applied cycle difficulty (SpawnInterval: %.2f -> %.2f, MaxEnemies: %d -> %d, ActiveInterval: %.2f)"),
+            PreviousSpawnInterval, SpawnInterval,
+            PreviousMaxEnemies, MaxEnemies,
+            CurrentSpawnInterval);
     }
 }
 
@@ -309,14 +361,7 @@ void ACC_EnemySpawner::UpdateSpawnInterval()
         // Restart timer with new interval
         if (bIsSpawning)
         {
-            GetWorld()->GetTimerManager().ClearTimer(SpawnTimerHandle);
-            GetWorld()->GetTimerManager().SetTimer(
-                SpawnTimerHandle,
-                this,
-                &ACC_EnemySpawner::SpawnEnemies,
-                CurrentSpawnInterval,
-                true
-            );
+            RefreshSpawnTimer();
 
             CC_LOG_SPAWNER(VeryVerbose, TEXT("Spawn interval updated to %.2fs (%.1f min elapsed)"),
                 CurrentSpawnInterval, MinutesPlayed);
@@ -396,4 +441,49 @@ void ACC_EnemySpawner::FindPlayer()
     {
         CC_LOG_SPAWNER(Warning, TEXT("Could not find player"));
     }
+}
+
+void ACC_EnemySpawner::SyncWithActiveCycle()
+{
+    ACC_CycleManager* CycleManager = FindCycleManager();
+    if (!CycleManager || !CycleManager->IsCycleActive())
+    {
+        return;
+    }
+
+    ApplyCycleConfig(CycleManager->GetCurrentCycleConfig());
+
+    CC_LOG_SPAWNER(Log, TEXT("Synced spawn settings from active cycle %d"), CycleManager->GetCurrentCycle());
+}
+
+ACC_CycleManager* ACC_EnemySpawner::FindCycleManager() const
+{
+    if (!GetWorld())
+    {
+        return nullptr;
+    }
+
+    for (TActorIterator<ACC_CycleManager> It(GetWorld()); It; ++It)
+    {
+        return *It;
+    }
+
+    return nullptr;
+}
+
+void ACC_EnemySpawner::RefreshSpawnTimer()
+{
+    if (!bIsSpawning || !GetWorld())
+    {
+        return;
+    }
+
+    GetWorld()->GetTimerManager().ClearTimer(SpawnTimerHandle);
+    GetWorld()->GetTimerManager().SetTimer(
+        SpawnTimerHandle,
+        this,
+        &ACC_EnemySpawner::SpawnEnemies,
+        CurrentSpawnInterval,
+        true
+    );
 }

--- a/Source/CristalCube/CC_EnemySpawner.h
+++ b/Source/CristalCube/CC_EnemySpawner.h
@@ -9,6 +9,8 @@
 
 class ACC_EnemyCharacter;
 class ACC_PlayerCharacter;
+class ACC_CycleManager;
+struct FCycleConfig;
 
 UCLASS()
 class CRISTALCUBE_API ACC_EnemySpawner : public AActor, public ICC_Freezable
@@ -110,6 +112,8 @@ protected:
 // SPAWNING
 //==========================================================================
 
+public:
+
 /** Start spawning enemies */
     UFUNCTION(BlueprintCallable, Category = "Spawner")
     void StartSpawning();
@@ -121,6 +125,9 @@ protected:
     /** Spawn enemies immediately */
     UFUNCTION(BlueprintCallable, Category = "Spawner")
     void SpawnEnemies();
+
+    /** Apply the current cycle's difficulty values to spawning behavior */
+    void ApplyCycleConfig(const FCycleConfig& CycleConfig);
 
     /** Spawn a single enemy at location */
     UFUNCTION(BlueprintCallable, Category = "Spawner")
@@ -173,4 +180,13 @@ protected:
 
     /** Find and cache player reference */
     void FindPlayer();
+
+    /** Pull the active cycle config if a cycle is already running */
+    void SyncWithActiveCycle();
+
+    /** Find the current cycle manager in the world */
+    ACC_CycleManager* FindCycleManager() const;
+
+    /** Rebuild the active spawn timer with the current interval */
+    void RefreshSpawnTimer();
 };


### PR DESCRIPTION
## 왜 이 변경이 필요한가요?
`FCycleConfig` 에는 사이클별 스폰 난이도 값이 이미 정의되어 있었지만, 실제 런타임에서는 이 값들이 로그로만 남고 있었습니다. 그 결과 사이클이 올라가도 게임 플레이에서 체감되는 적 압박은 거의 그대로였고, 사이클 설정과 실플레이가 분리된 상태였습니다.

이번 PR은 사이클 시작 시점의 설정이 실제 스포너 동작에 반영되도록 연결해서, 사이클 진행이 곧바로 적 스폰 밀도와 템포 변화로 이어지게 만드는 작업입니다.

## 무엇이 어떻게 바뀌었나요?
- `ACC_CycleManager` 가 사이클 시작 시 현재 `FCycleConfig` 를 월드에 존재하는 `ACC_EnemySpawner` 들에 직접 적용하도록 변경했습니다.
- `ACC_EnemySpawner` 에는 사이클 설정을 받아 런타임 스폰 상태에 반영하는 작은 API를 추가했습니다.
- 현재 PR 범위에서는 스폰 관련 값인 `MaxEnemies`, `SpawnInterval` 이 실제 스포너 동작에 반영됩니다.
- 이미 활성화되어 있는 스포너는 새 사이클 설정이 들어오면 반복 스폰 타이머를 다시 구성해서, 다음 레벨 로드나 수동 재설정 없이 즉시 변화가 반영되도록 했습니다.
- 사이클이 이미 진행 중인 상태에서 스포너가 늦게 시작되거나 언프리즈되더라도, 활성 사이클의 설정을 다시 읽어와 동일한 기준으로 동작하도록 맞췄습니다.

## 리뷰어가 특히 보면 좋은 코드 경로
아래 흐름을 중심으로 봐주시면 됩니다.
- `Source/CristalCube/CC_CycleManager.cpp`
  - `StartCycle()`
  - `ApplyCycleConfigToSpawners()`
- `Source/CristalCube/CC_EnemySpawner.cpp`
  - `BeginPlay()`
  - `StartSpawning()`
  - `ApplyCycleConfig()`
  - `SyncWithActiveCycle()`
  - `RefreshSpawnTimer()`
- `Source/CristalCube/CC_EnemySpawner.h`
  - 스포너가 사이클 설정을 받는 새 API 표면

## 기대 동작 예시
### 사이클 1
- 사이클 1 시작 시, 현재 월드에 살아 있는 각 스포너가 사이클 1의 설정값을 전달받습니다.
- 스포너는 사이클 1의 `MaxEnemies` 를 기준으로 동시 생존 적 수를 제한합니다.
- 스포너는 사이클 1의 `SpawnInterval` 을 기준으로 다음 스폰 타이밍을 잡습니다.
- 스포너가 사이클 시작 직후가 아니라 약간 늦게 활성화되더라도, 현재 활성 사이클 설정을 다시 동기화한 뒤 스폰을 시작합니다.

### 사이클 2 이후
- 다음 사이클이 시작되면 같은 스포너가 새 사이클의 `MaxEnemies`, `SpawnInterval` 값을 즉시 적용받습니다.
- 이미 스폰 중인 스포너라면 반복 타이머를 다시 설정해서 새 간격이 실시간으로 반영됩니다.
- 새 사이클의 `MaxEnemies` 가 현재 살아 있는 적 수보다 작다면, 살아 있는 적 수가 제한 아래로 내려갈 때까지 추가 스폰은 발생하지 않습니다.

## 남아 있는 한계와 후속 개선 포인트
- 이번 PR은 스폰 관련 난이도 연결에 집중했습니다. `EnemyDamageMultiplier`, `EnemySpeedMultiplier` 는 아직 실제 적 스탯 시스템에 연결된 소비 지점이 없어서 후속 작업이 필요합니다.
- 현재 스포너 탐색은 사이클 시작 시 월드 스캔 방식으로 처리하고 있습니다. 현재 구조에서는 안전하지만, 스포너 수가 많아지면 추후 명시적 등록 방식으로 바꾸는 것도 고려할 수 있습니다.
- 이 환경에는 `UnrealBuildTool` 이 없어 실제 Unreal 컴파일 검증은 수행하지 못했고, 이번 변경은 코드 리뷰와 `git diff --check` 기준으로 점검했습니다.
