### PR TITLE
feat: Cube Clear 보상이 실제 플레이어 상태에 적용되도록 연결

### DIFF
--- a/Source/CristalCube/CC_MainGameMode.cpp
+++ b/Source/CristalCube/CC_MainGameMode.cpp
@@ -64,7 +64,15 @@ void ACC_MainGameMode::ShowCubeClearUI(int32 ClearedCycle)
     {
         UE_LOG(LogTemp, Warning,
             TEXT("[MainGameMode] CubeClearWidgetClass not set! Auto-proceeding."));
-        OnCubeClearRewardSelected(FCubeClearReward());
+
+        HideCubeClearUI();
+        SetGameState(EGameState::Playing);
+
+        if (CycleManager)
+        {
+            CycleManager->StartNextCycle();
+        }
+
         return;
     }
 
@@ -75,6 +83,7 @@ void ACC_MainGameMode::ShowCubeClearUI(int32 ClearedCycle)
     if (CurrentCubeClearWidget)
     {
         CurrentCubeClearWidget->AddToViewport();
+        UGameplayStatics::SetGamePaused(GetWorld(), true);
         PC->SetInputMode(FInputModeUIOnly());
         PC->SetShowMouseCursor(true);
     }
@@ -91,6 +100,7 @@ void ACC_MainGameMode::HideCubeClearUI()
     APlayerController* PC = UGameplayStatics::GetPlayerController(this, 0);
     if (PC)
     {
+        UGameplayStatics::SetGamePaused(GetWorld(), false);
         PC->SetInputMode(FInputModeGameOnly());
         PC->SetShowMouseCursor(false);
     }
@@ -101,10 +111,13 @@ void ACC_MainGameMode::OnCubeClearRewardSelected(FCubeClearReward SelectedReward
     HideCubeClearUI();
     SetGameState(EGameState::Playing);
 
-    // 보상 적용 — 블루프린트에서 오버라이드하거나 PlayerCharacter에 위임
+    const bool bRewardApplied = ApplyCubeClearRewardToPlayer(SelectedReward);
+
     UE_LOG(LogTemp, Log,
-        TEXT("[MainGameMode] Reward selected: %s. Starting next cycle."),
-        *SelectedReward.DisplayName.ToString());
+        TEXT("[MainGameMode] Reward selected: %s (%s). Applied=%s. Starting next cycle."),
+        *SelectedReward.DisplayName.ToString(),
+        *UEnum::GetValueAsString(SelectedReward.RewardType),
+        bRewardApplied ? TEXT("true") : TEXT("false"));
 
     if (CycleManager)
     {
@@ -150,4 +163,17 @@ void ACC_MainGameMode::TriggerGameOver()
             GameOverTimerHandle, this, &ACC_MainGameMode::RestartCurrentLevel, GameOverDelay, false);
     }
     // GameOverDelay == 0 이면 블루프린트(WBP_GameOver)에서 수동 처리
+}
+
+bool ACC_MainGameMode::ApplyCubeClearRewardToPlayer(const FCubeClearReward& SelectedReward)
+{
+    ACC_PlayerCharacter* PlayerCharacter = GetPlayerCharacter();
+    if (!PlayerCharacter)
+    {
+        UE_LOG(LogTemp, Warning,
+            TEXT("[MainGameMode] Failed to apply Cube Clear reward: player character not found."));
+        return false;
+    }
+
+    return PlayerCharacter->ApplyCubeClearReward(SelectedReward);
 }

--- a/Source/CristalCube/CC_MainGameMode.h
+++ b/Source/CristalCube/CC_MainGameMode.h
@@ -93,6 +93,7 @@ public:
 
 private:
     void SpawnCycleManager();
+    bool ApplyCubeClearRewardToPlayer(const FCubeClearReward& SelectedReward);
 
     UFUNCTION()
     void OnCubeCleared(int32 ClearedCycle);

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
@@ -78,6 +78,8 @@ void ACC_PlayerCharacter::BeginPlay()
 {
 	Super::BeginPlay();
 
+	BaseMaxHealth = MaxHealth;
+
 	CC_LOG_PLAYER(Warning, "PlayerCharacter BeginPlay completed - Input handled by PlayerController");
 	CC_LOG_PLAYER(Warning, "Camera Distance: %.1f, Angle: %.1f",
 		CameraBoom->TargetArmLength,
@@ -814,11 +816,25 @@ void ACC_PlayerCharacter::UpdateGameHUD()
 
 }
 
+void ACC_PlayerCharacter::RefreshWeaponAutoAttacks()
+{
+	TArray<ACC_Weapon*> EquippedWeaponSnapshot = EquippedWeapons;
+
+	for (ACC_Weapon* Weapon : EquippedWeaponSnapshot)
+	{
+		if (!IsValid(Weapon))
+		{
+			continue;
+		}
+
+		StopWeaponAutoAttack(Weapon);
+		StartWeaponAutoAttack(Weapon);
+	}
+}
+
 float ACC_PlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
 	float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
-
-	CurrentHealth = FMath::Max(0.0f, CurrentHealth - ActualDamage);
 
 	UpdateGameHUD();
 
@@ -935,19 +951,167 @@ void ACC_PlayerCharacter::OnWeaponSelected(FName WeaponName)
 	HideLevelUpUI();
 }
 
-void ACC_PlayerCharacter::ApplyWeaponUpgrade(FName WeaponID)
+bool ACC_PlayerCharacter::ApplyCubeClearReward(const FCubeClearReward& Reward)
 {
-	UCC_WeaponManagerSubsystem* WeaponMgr = GetGameInstance()
-		->GetSubsystem<UCC_WeaponManagerSubsystem>();
-
-	FWeaponData* Data = WeaponMgr->GetWeaponDataPtr(WeaponID);
-
-	if (Data && Data->WeaponClass)
+	switch (Reward.RewardType)
 	{
-		CreateAndEquipWeapon(Data->WeaponClass);
+	case ECubeClearRewardType::HealFull:
+		return ApplyFullHealReward();
+
+	case ECubeClearRewardType::WeaponUpgrade:
+		return ApplyWeaponUpgrade(Reward.DataRowName);
+
+	case ECubeClearRewardType::StatBoost:
+		return ApplyStatBoostReward(Reward.StatUpgradeType, Reward.StatValue);
+
+	case ECubeClearRewardType::SkillGrant:
+		return ApplySkillGrant(Reward.DataRowName);
+
+	default:
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Unsupported Cube Clear reward type."));
+		return false;
+	}
+}
+
+bool ACC_PlayerCharacter::ApplyFullHealReward()
+{
+	const float HealedAmount = Heal(MaxHealth);
+	UpdateGameHUD();
+
+	UE_LOG(LogTemp, Log, TEXT("[Player] Cube Clear reward applied: Full Heal (%.1f restored)"), HealedAmount);
+	return true;
+}
+
+bool ACC_PlayerCharacter::ApplyStatBoostReward(EUpgradeType UpgradeType, float StatValue)
+{
+	if (UpgradeType == EUpgradeType::None)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear stat boost rejected: invalid upgrade type."));
+		return false;
 	}
 
-	UGameplayStatics::SetGamePaused(GetWorld(), false);
+	if (StatValue <= 0.0f)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear stat boost rejected: invalid value %.2f"), StatValue);
+		return false;
+	}
+
+	// Accept either delta values (0.2 = +20%) or multiplier values (1.2 = x1.2).
+	const float StatDelta = StatValue >= 1.0f ? (StatValue - 1.0f) : StatValue;
+
+	switch (UpgradeType)
+	{
+	case EUpgradeType::Damage:
+		PlayerStats.BasicStats.DamageMultiplier += StatDelta;
+		break;
+
+	case EUpgradeType::AttackSpeed:
+		PlayerStats.BasicStats.AttackSpeedMultiplier += StatDelta;
+		break;
+
+	case EUpgradeType::MoveSpeed:
+		PlayerStats.BasicStats.MoveSpeedMultiplier += StatDelta;
+		break;
+
+	case EUpgradeType::Health:
+		PlayerStats.BasicStats.HealthMultiplier += StatDelta;
+		break;
+
+	default:
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear stat boost type is not implemented yet."));
+		return false;
+	}
+
+	ApplyPlayerStats();
+	RefreshWeaponAutoAttacks();
+	UpdateGameHUD();
+
+	UE_LOG(LogTemp, Log, TEXT("[Player] Cube Clear stat boost applied: %s +%.2f"),
+		*UEnum::GetValueAsString(UpgradeType), StatDelta);
+	return true;
+}
+
+bool ACC_PlayerCharacter::ApplyWeaponUpgrade(FName WeaponID)
+{
+	if (WeaponID.IsNone())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear weapon reward rejected: invalid row name."));
+		return false;
+	}
+
+	if (!WeaponManager)
+	{
+		InitializeWeaponSystem();
+	}
+
+	if (!WeaponManager)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear weapon reward rejected: WeaponManager unavailable."));
+		return false;
+	}
+
+	FWeaponData* Data = WeaponManager->GetWeaponDataPtr(WeaponID);
+
+	if (!Data || !Data->WeaponClass)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cube Clear weapon reward rejected: %s not found."),
+			*WeaponID.ToString());
+		return false;
+	}
+
+	ACC_Weapon* ExistingWeapon = FindWeaponByClass(Data->WeaponClass);
+	const int32 CurrentUpgradeLevel = WeaponRewardLevels.FindRef(WeaponID);
+	const int32 MaxUpgradeLevel = FMath::Max(Data->MaxLevel - 1, 0);
+
+	if (ExistingWeapon)
+	{
+		if (CurrentUpgradeLevel >= MaxUpgradeLevel)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("[Player] %s is already at max reward level (%d)."),
+				*WeaponID.ToString(), Data->MaxLevel);
+			return false;
+		}
+
+		if (!ExistingWeapon->ApplyUpgrade())
+		{
+			return false;
+		}
+
+		WeaponRewardLevels.Add(WeaponID, CurrentUpgradeLevel + 1);
+		RefreshWeaponAutoAttacks();
+
+		UE_LOG(LogTemp, Log, TEXT("[Player] Cube Clear weapon upgraded: %s -> reward level %d/%d"),
+			*WeaponID.ToString(), CurrentUpgradeLevel + 1, MaxUpgradeLevel);
+		return true;
+	}
+
+	if (!CanEquipMoreWeapons())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Cannot grant weapon %s: no empty weapon slot."),
+			*WeaponID.ToString());
+		return false;
+	}
+
+	ACC_Weapon* NewWeapon = CreateAndEquipWeapon(Data->WeaponClass);
+	if (!NewWeapon)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[Player] Failed to create reward weapon: %s"),
+			*WeaponID.ToString());
+		return false;
+	}
+
+	WeaponRewardLevels.FindOrAdd(WeaponID) = 0;
+	UpdateGameHUD();
+
+	UE_LOG(LogTemp, Log, TEXT("[Player] Cube Clear weapon granted: %s"), *WeaponID.ToString());
+	return true;
+}
+
+bool ACC_PlayerCharacter::ApplySkillGrant(FName SkillID)
+{
+	UE_LOG(LogTemp, Warning, TEXT("[Player] SkillGrant reward is not implemented yet: %s"),
+		*SkillID.ToString());
+	return false;
 }
 
 void ACC_PlayerCharacter::ApplyStats()
@@ -960,18 +1124,26 @@ void ACC_PlayerCharacter::ApplyStats()
 		Movement->MaxWalkSpeed = FinalMoveSpeed;
 	}
 
-	// Apply health multiplier
-	float FinalMaxHealth = MaxHealth * PlayerStats.BasicStats.HealthMultiplier;
+	const float PreviousMaxHealth = MaxHealth;
+	if (BaseMaxHealth <= 0.0f)
+	{
+		BaseMaxHealth = PreviousMaxHealth;
+	}
+
+	// Apply health multiplier from the original max health so repeated rewards do not compound twice.
+	const float FinalMaxHealth = BaseMaxHealth * PlayerStats.BasicStats.HealthMultiplier;
 
 	// If health was at max, keep it at max after stat change
-	if (FMath::IsNearlyEqual(CurrentHealth, MaxHealth))
+	if (FMath::IsNearlyEqual(CurrentHealth, PreviousMaxHealth))
 	{
 		CurrentHealth = FinalMaxHealth;
 	}
 	else
 	{
 		// Otherwise, adjust current health proportionally
-		float HealthPercentage = CurrentHealth / MaxHealth;
+		const float HealthPercentage = PreviousMaxHealth > 0.0f
+			? (CurrentHealth / PreviousMaxHealth)
+			: 1.0f;
 		CurrentHealth = FinalMaxHealth * HealthPercentage;
 	}
 

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.h
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.h
@@ -273,7 +273,14 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Stats")
 	float GameTime = 0.0f;
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Cube Clear")
+	TMap<FName, int32> WeaponRewardLevels;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Stats")
+	float BaseMaxHealth = 0.0f;
+
 	void UpdateGameHUD();
+	void RefreshWeaponAutoAttacks();
 
 
 
@@ -314,8 +321,20 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void OnWeaponSelected(FName WeaponName);
 
-	UFUNCTION(BlueprintCallable)
-	void ApplyWeaponUpgrade(FName WeaponID);
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyCubeClearReward(const FCubeClearReward& Reward);
+
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyFullHealReward();
+
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyStatBoostReward(EUpgradeType UpgradeType, float StatValue);
+
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyWeaponUpgrade(FName WeaponID);
+
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplySkillGrant(FName SkillID);
 
 	/** Returns CameraBoom subobject */
 	FORCEINLINE USpringArmComponent* GetCameraBoom() const { return CameraBoom; }

--- a/Source/CristalCube/WeaponSystems/CC_Weapon.cpp
+++ b/Source/CristalCube/WeaponSystems/CC_Weapon.cpp
@@ -30,6 +30,9 @@ ACC_Weapon::ACC_Weapon()
 	bCanAttack = true;                    // Ready to attack
 	LastAttackTime = 0.0f;                // No previous attack
 	WeaponOwner = nullptr;                // No owner yet
+	UpgradeLevel = 0;
+	DamageMultiplierPerUpgrade = 0.25f;
+	AttackSpeedMultiplierPerUpgrade = 0.15f;
 
 	// Initialize effects (set in Blueprint or child classes)
 	AttackEffect = nullptr;
@@ -66,7 +69,8 @@ void ACC_Weapon::Attack()
 	PlayAttackEffects();
 
 	// Schedule cooldown reset based on attack speed
-	float CooldownDuration = 1.0f / BaseStats.AttackSpeed;
+	const float EffectiveAttackSpeed = FMath::Max(GetAttackSpeed(), KINDA_SMALL_NUMBER);
+	float CooldownDuration = 1.0f / EffectiveAttackSpeed;
 	GetWorld()->GetTimerManager().SetTimer(
 		AttackCooldownTimer,
 		this,
@@ -91,7 +95,8 @@ bool ACC_Weapon::CanAttack() const
 
 	// Verify cooldown has expired
 	float CurrentTime = GetWorld()->GetTimeSeconds();
-	float CooldownDuration = 1.0f / BaseStats.AttackSpeed;
+	const float EffectiveAttackSpeed = FMath::Max(GetAttackSpeed(), KINDA_SMALL_NUMBER);
+	float CooldownDuration = 1.0f / EffectiveAttackSpeed;
 	return (CurrentTime - LastAttackTime) >= CooldownDuration;
 }
 
@@ -113,6 +118,27 @@ void ACC_Weapon::OnUnequipped()
 	DetachFromActor(FDetachmentTransformRules::KeepWorldTransform);
 
 	UE_LOG(LogTemp, Log, TEXT("Weapon Uneauipped"));
+}
+
+float ACC_Weapon::GetAttackSpeed() const
+{
+	float FinalAttackSpeed = BaseStats.AttackSpeed * (1.0f + (UpgradeLevel * AttackSpeedMultiplierPerUpgrade));
+
+	if (const ACC_PlayerCharacter* PlayerCharacter = Cast<ACC_PlayerCharacter>(WeaponOwner))
+	{
+		FinalAttackSpeed *= PlayerCharacter->GetFinalAttackSpeedMultiplier();
+	}
+
+	return FinalAttackSpeed;
+}
+
+bool ACC_Weapon::ApplyUpgrade()
+{
+	++UpgradeLevel;
+
+	UE_LOG(LogTemp, Log, TEXT("[Weapon] %s upgraded to level %d"),
+		*GetName(), UpgradeLevel);
+	return true;
 }
 
 void ACC_Weapon::PerformRangedAttack()
@@ -200,7 +226,12 @@ void ACC_Weapon::PlayAttackEffects()
 
 float ACC_Weapon::CalculateFinalDamage() const
 {
-	float FinalDamage = BaseStats.BaseDamage;
+	float FinalDamage = BaseStats.BaseDamage * (1.0f + (UpgradeLevel * DamageMultiplierPerUpgrade));
+
+	if (const ACC_PlayerCharacter* PlayerCharacter = Cast<ACC_PlayerCharacter>(WeaponOwner))
+	{
+		FinalDamage *= PlayerCharacter->GetFinalDamageMultiplier();
+	}
 
 	return FinalDamage;
 }

--- a/Source/CristalCube/WeaponSystems/CC_Weapon.h
+++ b/Source/CristalCube/WeaponSystems/CC_Weapon.h
@@ -60,6 +60,15 @@ protected:
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon State")
 	AActor* WeaponOwner;
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Weapon|Upgrade")
+	int32 UpgradeLevel;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon|Upgrade")
+	float DamageMultiplierPerUpgrade;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadOnly, Category = "Weapon|Upgrade")
+	float AttackSpeedMultiplierPerUpgrade;
+
 	// Projectile class to spawn (for Ranged weapons)
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Weapon|Ranged", meta = (EditCondition = "BaseStats.WeaponCategory == EWeaponCategory::Ranged", EditConditionHides))
 	TSubclassOf<class ACC_Projectile> ProjectileClass;
@@ -107,7 +116,13 @@ public:
 	float GetBaseDamage() const { return BaseStats.BaseDamage; }
 
 	UFUNCTION(BlueprintPure, Category = "Weapon")
-	float GetAttackSpeed() const { return BaseStats.AttackSpeed; }
+	float GetAttackSpeed() const;
+
+	UFUNCTION(BlueprintPure, Category = "Weapon")
+	int32 GetUpgradeLevel() const { return UpgradeLevel; }
+
+	UFUNCTION(BlueprintCallable, Category = "Weapon")
+	bool ApplyUpgrade();
 
 	//==========================================================================
 // TYPE-SPECIFIC ATTACK FUNCTIONS

--- a/Source/CristalCube/WeaponSystems/Weapon_Magic/CC_BasicMagic.cpp
+++ b/Source/CristalCube/WeaponSystems/Weapon_Magic/CC_BasicMagic.cpp
@@ -37,7 +37,8 @@ void ACC_BasicMagic::Attack()
 
     ExecuteMagicAttack();
 
-    float CooldownDuration = 1.0f / BaseStats.AttackSpeed;
+    const float EffectiveAttackSpeed = FMath::Max(GetAttackSpeed(), KINDA_SMALL_NUMBER);
+    float CooldownDuration = 1.0f / EffectiveAttackSpeed;
     GetWorld()->GetTimerManager().SetTimer(
         AttackCooldownTimer,
         this,

--- a/Source/CristalCube/WeaponSystems/Weapon_Melee/CC_BasicSword.cpp
+++ b/Source/CristalCube/WeaponSystems/Weapon_Melee/CC_BasicSword.cpp
@@ -30,7 +30,8 @@ void ACC_BasicSword::Attack()
 
 	ExecuteSwordAttack();
 
-	float CooldownDuration = 1.0f / BaseStats.AttackSpeed;
+	const float EffectiveAttackSpeed = FMath::Max(GetAttackSpeed(), KINDA_SMALL_NUMBER);
+	float CooldownDuration = 1.0f / EffectiveAttackSpeed;
 	GetWorld()->GetTimerManager().SetTimer(
 		AttackCooldownTimer,
 		this,

--- a/Source/CristalCube/WeaponSystems/Weapon_Range/CC_BasicGun.cpp
+++ b/Source/CristalCube/WeaponSystems/Weapon_Range/CC_BasicGun.cpp
@@ -41,7 +41,8 @@ void ACC_BasicGun::Attack()
     ExecuteGunAttack();
 
     // Schedule cooldown reset
-    float CooldownDuration = 1.0f / BaseStats.AttackSpeed;
+    const float EffectiveAttackSpeed = FMath::Max(GetAttackSpeed(), KINDA_SMALL_NUMBER);
+    float CooldownDuration = 1.0f / EffectiveAttackSpeed;
     GetWorld()->GetTimerManager().SetTimer(
         AttackCooldownTimer,
         this,


### PR DESCRIPTION
## 배경
현재 Cube Clear 보상 시스템은 보상 구조체와 UI 진입 흐름은 이미 들어와 있었지만, 실제 선택 결과가 플레이어 상태나 전투 로직에 반영되지 않는 상태였습니다.

즉, 플레이어가 보상을 선택해도 실제로는 다음 사이클만 시작되고 있었고, 아래와 같은 빈 구간이 남아 있었습니다.
- `ACC_MainGameMode::OnCubeClearRewardSelected` 에서 보상 선택 후 로그만 남기고 다음 사이클로 진행됨
- `HealFull`, `WeaponUpgrade`, `StatBoost` 가 실제 HP, 무기 상태, 스탯 수치에 연결되지 않음
- 플레이어 스탯 multiplier가 무기 데미지/공격 속도 계산에 반영되지 않음
- Cube Clear UI 구간이 pause되지 않아 선택 흐름이 다소 어색할 수 있음

이번 PR은 이 미완성 구간을 메워서, Cube Clear 보상 선택이 실제 게임 상태 변화로 이어지도록 만드는 작업입니다.

## 이번 PR에서 구현한 보상 타입
### 1. `HealFull`
- 선택 즉시 플레이어 체력을 최대치까지 회복합니다.
- HUD도 바로 갱신되도록 연결했습니다.

### 2. `WeaponUpgrade`
- 지정된 무기를 아직 보유하지 않았다면 새로 지급합니다.
- 이미 보유 중인 무기라면 업그레이드 레벨을 올립니다.
- 업그레이드된 무기는 실제 데미지와 공격 속도 계산에 반영됩니다.
- 업그레이드 적용 후 auto-attack 타이머도 다시 맞춰, 체감이 바로 나도록 했습니다.

### 3. `StatBoost`
- `Damage`, `AttackSpeed`, `MoveSpeed`, `Health` 를 플레이어의 기본 multiplier에 반영합니다.
- 적용 즉시 이동 속도 / 체력 / 무기 공격 주기에 영향이 가도록 연결했습니다.
- `Health` 보상은 기존 `MaxHealth` 에 누적 곱이 꼬이지 않도록, base max health 기준으로 다시 계산하도록 정리했습니다.

## 이번 PR에서 아직 구현하지 않은 보상 타입
### `SkillGrant`
- 이번 PR에서는 apply entry point만 만들어 두었습니다.
- 실제 스킬 지급 로직과 `SkillSystem` 연결은 아직 하지 않았습니다.
- 다음 작업에서 붙이기 쉬운 구조로 정리해 둔 상태입니다.

## 주요 변경 내용
### 1. 보상 적용 책임 정리
- `ACC_MainGameMode` 는 Cube Clear UI 표시, 선택 완료 처리, 다음 사이클 시작을 담당합니다.
- 실제 보상 적용은 `ACC_PlayerCharacter` 로 위임하도록 정리했습니다.
- 이로써 보상 선택 orchestration 과 플레이어 상태 변경 책임이 분리됩니다.

### 2. Cube Clear 선택 흐름 정리
- Cube Clear UI가 뜨는 동안 월드를 pause 하도록 맞췄습니다.
- 선택이 끝나면 UI를 닫고, pause를 해제하고, 입력을 원래대로 돌린 뒤 다음 사이클을 시작합니다.
- 선택 후 다음 사이클로 넘어가는 흐름이 레벨업 UI와 비슷한 감각으로 이어지도록 맞췄습니다.

### 3. 실제 전투 수치 반영
- 플레이어의 `DamageMultiplier`, `AttackSpeedMultiplier` 가 무기 계산에 반영되도록 수정했습니다.
- 무기 자체 업그레이드 레벨도 추가해서, 보상으로 받은 강화가 실제 전투 성능으로 이어지게 했습니다.
- 각 무기 클래스의 cooldown 계산도 최종 공격 속도를 사용하도록 변경했습니다.

### 4. 같이 정리한 부분
- 플레이어가 피해를 받을 때 체력이 중복으로 깎이던 흐름도 같이 정리했습니다.
- 체력 multiplier가 여러 번 적용될 때 max health 계산이 꼬일 수 있던 구조도 함께 보완했습니다.

## 리뷰 포인트
### A. 보상 선택 흐름
다음 파일 기준으로 봐주시면 됩니다.
- `Source/CristalCube/CC_MainGameMode.h`
- `Source/CristalCube/CC_MainGameMode.cpp`

중점 확인 포인트:
- Cube Clear UI 표시 시 pause 처리
- 선택 완료 후 `GameMode -> PlayerCharacter` 로 보상 적용 위임
- 보상 적용 후 UI 종료, 입력 복구, 다음 사이클 시작

### B. 플레이어 상태 적용
다음 파일 기준으로 봐주시면 됩니다.
- `Source/CristalCube/Characters/CC_PlayerCharacter.h`
- `Source/CristalCube/Characters/CC_PlayerCharacter.cpp`

중점 확인 포인트:
- `HealFull`, `WeaponUpgrade`, `StatBoost`, `SkillGrant` 분기
- 보상 타입별 적용 책임이 플레이어 쪽에 모여 있는지
- `Health` 보상 반영 시 max health 재계산 방식이 안전한지
- auto-attack timer 재동기화가 적절한지

### C. 무기 수치 반영
다음 파일 기준으로 봐주시면 됩니다.
- `Source/CristalCube/WeaponSystems/CC_Weapon.h`
- `Source/CristalCube/WeaponSystems/CC_Weapon.cpp`
- `Source/CristalCube/WeaponSystems/Weapon_Range/CC_BasicGun.cpp`
- `Source/CristalCube/WeaponSystems/Weapon_Melee/CC_BasicSword.cpp`
- `Source/CristalCube/WeaponSystems/Weapon_Magic/CC_BasicMagic.cpp`

중점 확인 포인트:
- 무기 업그레이드 레벨이 실제 데미지/공속에 반영되는지
- 플레이어 multiplier와 무기 업그레이드가 함께 계산되는지
- 파생 무기들이 최종 공격 속도를 사용하도록 잘 따라가는지

## 실제 사용 흐름 예시
1. 플레이어가 현재 사이클의 Cube Clear 조건을 달성합니다.
2. Cube Clear UI가 열리고, 이 동안 게임은 pause 됩니다.
3. 플레이어가 `HealFull`, `WeaponUpgrade`, `StatBoost` 중 하나를 선택합니다.
4. 선택한 보상이 즉시 플레이어 HP / 장착 무기 / 스탯 / 공격 주기에 반영됩니다.
5. UI가 닫히고 pause가 해제되며, 다음 사이클이 자연스럽게 시작됩니다.

## 후속 개선 아이디어
- `SkillGrant` 를 실제 `SkillSystem` 지급 로직과 연결하기
- reward pool 단계에서 이미 max level 인 무기나 의미 없는 보상을 미리 제외하기
- Cube Clear 전용 C++ 위젯 클래스를 도입해서 UI와 데이터 연결을 더 명확하게 만들기
- 무기 업그레이드 수치를 DataTable 또는 reward 데이터 기반으로 더 세밀하게 조정하기

## 검증
- `git diff --check`
- 보상 선택 흐름, 플레이어 상태 반영, 무기 수치 반영 경로를 정적 검토

참고:
- 현재 작업 환경에는 Unreal Engine 5.6 빌드 도구가 없어 실제 compile/build 는 수행하지 못했습니다.
