### PR TITLE
test: ad-hoc tester actor 정리 및 최소 회귀 자동화 테스트 추가

### DIFF
--- a/Source/CristalCube/CC_CycleManager.cpp
+++ b/Source/CristalCube/CC_CycleManager.cpp
@@ -60,11 +60,11 @@ void ACC_CycleManager::BindToEnemyManager()
         return;
     }
 
-    EM->OnEnemyUnregistered.AddDynamic(this, &ACC_CycleManager::OnEnemyKilled);
-    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Bound to EnemyManager::OnEnemyUnregistered."));
+    EM->OnEnemyKilled.AddDynamic(this, &ACC_CycleManager::HandleEnemyKilled);
+    UE_LOG(LogTemp, Log, TEXT("[CycleManager] Bound to EnemyManager::OnEnemyKilled."));
 }
 
-void ACC_CycleManager::OnEnemyKilled(AActor* KilledEnemy)
+void ACC_CycleManager::HandleEnemyKilled(AActor* KilledEnemy)
 {
     if (!bCycleActive) return;
 
@@ -102,7 +102,7 @@ void ACC_CycleManager::StartCycle(int32 CycleNumber)
     FCycleConfig Config = GetCurrentCycleConfig();
 
     // 제한 시간 설정 (0이면 킬 수 기반)
-    if (Config.TimeLimit > 0.f)
+    if (Config.TimeLimit > 0.f && GetWorld())
     {
         GetWorldTimerManager().SetTimer(
             TimeLimitHandle, this,
@@ -122,7 +122,10 @@ void ACC_CycleManager::CheckCycleCompletion()
     if (KillsThisCycle < GetKillsRequired()) return;
 
     bCycleActive = false;
-    GetWorldTimerManager().ClearTimer(TimeLimitHandle);
+    if (GetWorld())
+    {
+        GetWorldTimerManager().ClearTimer(TimeLimitHandle);
+    }
 
     UE_LOG(LogTemp, Warning,
         TEXT("[CycleManager] === Cube %d CLEARED ==="), CurrentCycle);

--- a/Source/CristalCube/CC_CycleManager.h
+++ b/Source/CristalCube/CC_CycleManager.h
@@ -50,7 +50,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnKillCountUpdated, int32, Current
  * CC_MainGameMode에서 Spawn하여 참조.
  *
  * EnemyManager 연동:
- *   EnemyManager::OnEnemyUnregistered → OnEnemyKilled() 자동 호출
+ *   EnemyManager::OnEnemyKilled → HandleEnemyKilled() 자동 호출
  *   EnemyCharacter/CycleManager 간 직접 의존 없음
  *
  * 사이클 흐름:
@@ -147,14 +147,13 @@ public:
     UFUNCTION(BlueprintPure, Category = "Cycle")
     int32 GetKillsThisCycle() const { return KillsThisCycle; }
 
+    UFUNCTION(BlueprintCallable, Category = "Cycle")
+    void HandleEnemyKilled(AActor* KilledEnemy);
+
 private:
 
     void StartCycle(int32 CycleNumber);
     void CheckCycleCompletion();
-
-    /** 적 처치 시 호출 (EnemyCharacter 사망 시 연결) */
-    UFUNCTION(BlueprintCallable, Category = "Cycle")
-    void OnEnemyKilled(AActor* KilledEnemy);
 
     void BindToEnemyManager();
 

--- a/Source/CristalCube/CC_EnemyManager.cpp
+++ b/Source/CristalCube/CC_EnemyManager.cpp
@@ -120,12 +120,29 @@ void ACC_EnemyManager::UnregisterEnemy(AActor* Enemy)
     }
 
     PendingRemoval.Add(Enemy);
-
-    // CycleManager에 킬 알림 (직접 참조 없이 델리게이트로)
     OnEnemyUnregistered.Broadcast(Enemy);
 
     UE_LOG(LogTemp, VeryVerbose, TEXT("[ENEMY MANAGER] Unregistered enemy (Total: %d)"), ActiveEnemies.Num());
 
+}
+
+void ACC_EnemyManager::NotifyEnemyKilled(AActor* Enemy)
+{
+    if (!Enemy || PendingRemoval.Contains(Enemy))
+    {
+        return;
+    }
+
+    if (!ActiveEnemies.Contains(Enemy))
+    {
+        return;
+    }
+
+    PendingRemoval.Add(Enemy);
+    OnEnemyKilled.Broadcast(Enemy);
+    OnEnemyUnregistered.Broadcast(Enemy);
+
+    UE_LOG(LogTemp, Log, TEXT("[ENEMY MANAGER] Enemy killed: %s"), *Enemy->GetName());
 }
 
 AActor* ACC_EnemyManager::GetNearestEnemy(const FVector& Location, float MaxRadius)

--- a/Source/CristalCube/CC_EnemyManager.h
+++ b/Source/CristalCube/CC_EnemyManager.h
@@ -7,6 +7,7 @@
 #include "CC_EnemyManager.generated.h"
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnemyUnregistered, AActor*, Enemy);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnEnemyKilled, AActor*, Enemy);
 /**
  * Central manager for all enemies
  * Provides optimized enemy queries for weapons
@@ -71,6 +72,9 @@ public:
     UFUNCTION(BlueprintCallable, Category = "Enemy Manager")
     void UnregisterEnemy(AActor* Enemy);
 
+    UFUNCTION(BlueprintCallable, Category = "Enemy Manager")
+    void NotifyEnemyKilled(AActor* Enemy);
+
     // Get nearest enemy to location (FAST!)
     UFUNCTION(BlueprintPure, Category = "Enemy Manager")
     AActor* GetNearestEnemy(const FVector& Location, float MaxRadius = 10000.0f);
@@ -89,6 +93,9 @@ public:
 
     UPROPERTY(BlueprintAssignable, Category = "Enemy Manager")
     FOnEnemyUnregistered OnEnemyUnregistered;
+
+    UPROPERTY(BlueprintAssignable, Category = "Enemy Manager")
+    FOnEnemyKilled OnEnemyKilled;
 
 protected:
     // Update cache

--- a/Source/CristalCube/CC_MainGameMode.cpp
+++ b/Source/CristalCube/CC_MainGameMode.cpp
@@ -101,10 +101,16 @@ void ACC_MainGameMode::OnCubeClearRewardSelected(FCubeClearReward SelectedReward
     HideCubeClearUI();
     SetGameState(EGameState::Playing);
 
-    // 보상 적용 — 블루프린트에서 오버라이드하거나 PlayerCharacter에 위임
+    bool bRewardApplied = false;
+    if (ACC_PlayerCharacter* PlayerCharacter = GetPlayerCharacter())
+    {
+        bRewardApplied = PlayerCharacter->ApplyCubeClearReward(SelectedReward);
+    }
+
     UE_LOG(LogTemp, Log,
-        TEXT("[MainGameMode] Reward selected: %s. Starting next cycle."),
-        *SelectedReward.DisplayName.ToString());
+        TEXT("[MainGameMode] Reward selected: %s (Applied=%s). Starting next cycle."),
+        *SelectedReward.DisplayName.ToString(),
+        bRewardApplied ? TEXT("true") : TEXT("false"));
 
     if (CycleManager)
     {

--- a/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_EnemyCharacter.cpp
@@ -507,6 +507,11 @@ void ACC_EnemyCharacter::Die()
 		AIManager->UnregisterEnemy(this);
 	}
 
+	if (ACC_EnemyManager* Manager = ACC_EnemyManager::Get(this))
+	{
+		Manager->NotifyEnemyKilled(this);
+	}
+
 	// Call base class Die() to handle death animation, etc.
 	Super::Die();
 

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.cpp
@@ -140,6 +140,18 @@ void ACC_PlayerCharacter::ApplyPlayerStats()
 	ApplyStats();
 }
 
+void ACC_PlayerCharacter::CaptureBaseStatsIfNeeded()
+{
+	if (bHasCapturedBaseStats)
+	{
+		return;
+	}
+
+	BaseMaxHealthStat = MaxHealth;
+	BaseMoveSpeedStat = MoveSpeed;
+	bHasCapturedBaseStats = true;
+}
+
 void ACC_PlayerCharacter::InitializeWeaponSystem()
 {
 	UGameInstance* GameInstance = GetGameInstance();
@@ -816,11 +828,13 @@ void ACC_PlayerCharacter::UpdateGameHUD()
 
 float ACC_PlayerCharacter::TakeDamage(float DamageAmount, FDamageEvent const& DamageEvent, AController* EventInstigator, AActor* DamageCauser)
 {
-	float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
+	const float PreviousHealth = CurrentHealth;
+	const float ActualDamage = Super::TakeDamage(DamageAmount, DamageEvent, EventInstigator, DamageCauser);
 
-	CurrentHealth = FMath::Max(0.0f, CurrentHealth - ActualDamage);
-
-	UpdateGameHUD();
+	if (ActualDamage > 0.0f && !FMath::IsNearlyEqual(CurrentHealth, PreviousHealth))
+	{
+		UpdateGameHUD();
+	}
 
 	return ActualDamage;
 }
@@ -937,8 +951,19 @@ void ACC_PlayerCharacter::OnWeaponSelected(FName WeaponName)
 
 void ACC_PlayerCharacter::ApplyWeaponUpgrade(FName WeaponID)
 {
-	UCC_WeaponManagerSubsystem* WeaponMgr = GetGameInstance()
-		->GetSubsystem<UCC_WeaponManagerSubsystem>();
+	UGameInstance* GameInstance = GetGameInstance();
+	if (!GameInstance)
+	{
+		CC_LOG_PLAYER(Warning, TEXT("Cannot apply weapon upgrade without a game instance"));
+		return;
+	}
+
+	UCC_WeaponManagerSubsystem* WeaponMgr = GameInstance->GetSubsystem<UCC_WeaponManagerSubsystem>();
+	if (!WeaponMgr)
+	{
+		CC_LOG_PLAYER(Warning, TEXT("Cannot apply weapon upgrade without WeaponManagerSubsystem"));
+		return;
+	}
 
 	FWeaponData* Data = WeaponMgr->GetWeaponDataPtr(WeaponID);
 
@@ -947,31 +972,99 @@ void ACC_PlayerCharacter::ApplyWeaponUpgrade(FName WeaponID)
 		CreateAndEquipWeapon(Data->WeaponClass);
 	}
 
-	UGameplayStatics::SetGamePaused(GetWorld(), false);
+	if (UWorld* World = GetWorld())
+	{
+		UGameplayStatics::SetGamePaused(World, false);
+	}
+}
+
+bool ACC_PlayerCharacter::ApplyCubeClearReward(const FCubeClearReward& Reward)
+{
+	switch (Reward.RewardType)
+	{
+	case ECubeClearRewardType::WeaponUpgrade:
+		if (Reward.DataRowName.IsNone())
+		{
+			return false;
+		}
+
+		ApplyWeaponUpgrade(Reward.DataRowName);
+		return true;
+
+	case ECubeClearRewardType::SkillGrant:
+		UE_LOG(LogTemp, Warning, TEXT("[Player] SkillGrant reward is not implemented yet: %s"),
+			*Reward.DataRowName.ToString());
+		return false;
+
+	case ECubeClearRewardType::StatBoost:
+		return ApplyStatUpgrade(Reward.StatUpgradeType, Reward.StatValue);
+
+	case ECubeClearRewardType::HealFull:
+		return Heal(MaxHealth) > 0.0f || FMath::IsNearlyEqual(CurrentHealth, MaxHealth);
+	}
+
+	return false;
+}
+
+bool ACC_PlayerCharacter::ApplyStatUpgrade(EUpgradeType UpgradeType, float UpgradeValue)
+{
+	if (FMath::IsNearlyZero(UpgradeValue))
+	{
+		return false;
+	}
+
+	switch (UpgradeType)
+	{
+	case EUpgradeType::Damage:
+		PlayerStats.BasicStats.DamageMultiplier += UpgradeValue;
+		break;
+
+	case EUpgradeType::AttackSpeed:
+		PlayerStats.BasicStats.AttackSpeedMultiplier += UpgradeValue;
+		break;
+
+	case EUpgradeType::MoveSpeed:
+		PlayerStats.BasicStats.MoveSpeedMultiplier += UpgradeValue;
+		break;
+
+	case EUpgradeType::Health:
+		PlayerStats.BasicStats.HealthMultiplier += UpgradeValue;
+		break;
+
+	case EUpgradeType::None:
+	default:
+		return false;
+	}
+
+	ApplyPlayerStats();
+	UpdateGameHUD();
+	return true;
 }
 
 void ACC_PlayerCharacter::ApplyStats()
 {
 	Super::ApplyStats();
+	CaptureBaseStatsIfNeeded();
 
 	if (UCharacterMovementComponent* Movement = GetCharacterMovement())
 	{
-		float FinalMoveSpeed = MoveSpeed * PlayerStats.BasicStats.MoveSpeedMultiplier;
+		const float FinalMoveSpeed = BaseMoveSpeedStat * PlayerStats.BasicStats.MoveSpeedMultiplier;
 		Movement->MaxWalkSpeed = FinalMoveSpeed;
 	}
 
 	// Apply health multiplier
-	float FinalMaxHealth = MaxHealth * PlayerStats.BasicStats.HealthMultiplier;
+	const float PreviousMaxHealth = MaxHealth;
+	const float FinalMaxHealth = BaseMaxHealthStat * PlayerStats.BasicStats.HealthMultiplier;
 
 	// If health was at max, keep it at max after stat change
-	if (FMath::IsNearlyEqual(CurrentHealth, MaxHealth))
+	if (FMath::IsNearlyEqual(CurrentHealth, PreviousMaxHealth))
 	{
 		CurrentHealth = FinalMaxHealth;
 	}
 	else
 	{
 		// Otherwise, adjust current health proportionally
-		float HealthPercentage = CurrentHealth / MaxHealth;
+		const float HealthPercentage = PreviousMaxHealth > 0.0f ? (CurrentHealth / PreviousMaxHealth) : 0.0f;
 		CurrentHealth = FinalMaxHealth * HealthPercentage;
 	}
 

--- a/Source/CristalCube/Characters/CC_PlayerCharacter.h
+++ b/Source/CristalCube/Characters/CC_PlayerCharacter.h
@@ -48,6 +48,8 @@ protected:
 	UFUNCTION(BlueprintCallable, Category = "Stats")
 	void ApplyPlayerStats();
 
+	void CaptureBaseStatsIfNeeded();
+
 	// Getters
 	UFUNCTION(BlueprintCallable, Category = "Stats")
 	FCristalCubePlayerStats GetPlayerStats() const { return PlayerStats; }
@@ -317,6 +319,12 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void ApplyWeaponUpgrade(FName WeaponID);
 
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyCubeClearReward(const FCubeClearReward& Reward);
+
+	UFUNCTION(BlueprintCallable, Category = "Cube Clear")
+	bool ApplyStatUpgrade(EUpgradeType UpgradeType, float UpgradeValue);
+
 	/** Returns CameraBoom subobject */
 	FORCEINLINE USpringArmComponent* GetCameraBoom() const { return CameraBoom; }
 
@@ -330,6 +338,15 @@ public:
 
 protected:
 	// Override ApplyStats to include player-specific stat calculations
+
+	UPROPERTY(Transient)
+	bool bHasCapturedBaseStats = false;
+
+	UPROPERTY(Transient)
+	float BaseMaxHealthStat = 0.0f;
+
+	UPROPERTY(Transient)
+	float BaseMoveSpeedStat = 0.0f;
 
 	virtual void ApplyStats() override;
 

--- a/Source/CristalCube/CristalCube.Build.cs
+++ b/Source/CristalCube/CristalCube.Build.cs
@@ -12,6 +12,11 @@ public class CristalCube : ModuleRules
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 
+		if (Target.bBuildEditor)
+		{
+			PrivateDependencyModuleNames.Add("UnrealEd");
+		}
+
 		// Uncomment if you are using Slate UI
 		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
 		

--- a/Source/CristalCube/Test/CC_CubeSystemTester.cpp
+++ b/Source/CristalCube/Test/CC_CubeSystemTester.cpp
@@ -23,6 +23,7 @@ void ACC_CubeSystemTester::BeginPlay()
 
 	if (bAutoRunTests)
 	{
+		UE_LOG(LogTemp, Warning, TEXT("[CubeSystemTester] Legacy manual tester actor invoked. Prefer Unreal automation tests under CristalCube.Regression.* for regression coverage."));
 		// 딜레이 후 테스트 실행
 		GetWorld()->GetTimerManager().SetTimer(
 			TestTimerHandle,

--- a/Source/CristalCube/Test/CC_CubeSystemTester.h
+++ b/Source/CristalCube/Test/CC_CubeSystemTester.h
@@ -43,7 +43,7 @@ public:
 
 	/** 자동 테스트 실행 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Testing")
-	bool bAutoRunTests = true;
+	bool bAutoRunTests = false;
 
 	/** 테스트 시작 딜레이 */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Testing")

--- a/Source/CristalCube/Test/CC_RegressionAutomationTests.cpp
+++ b/Source/CristalCube/Test/CC_RegressionAutomationTests.cpp
@@ -1,0 +1,195 @@
+#if WITH_DEV_AUTOMATION_TESTS && WITH_EDITOR
+
+#include "Misc/AutomationTest.h"
+#include "Tests/AutomationEditorCommon.h"
+#include "CC_CycleManager.h"
+#include "CC_EnemyManager.h"
+#include "Characters/CC_PlayerCharacter.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+namespace CristalCube::Tests
+{
+	static UWorld* CreateTestWorld(FAutomationTestBase& Test)
+	{
+		UWorld* World = FAutomationEditorCommonUtils::CreateNewMap();
+		Test.TestNotNull(TEXT("Created automation map"), World);
+		return World;
+	}
+
+	static FCycleConfig MakeCycleConfig(const int32 KillsRequired)
+	{
+		FCycleConfig Config;
+		Config.KillsRequired = KillsRequired;
+		Config.TimeLimit = 0.0f;
+		Config.MaxEnemies = KillsRequired;
+		Config.SpawnInterval = 0.0f;
+		return Config;
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCCPlayerDamageSingleApplicationTest,
+	"CristalCube.Regression.Player.Damage.SingleApplication",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FCCPlayerDamageSingleApplicationTest::RunTest(const FString& Parameters)
+{
+	using namespace CristalCube::Tests;
+
+	UWorld* World = CreateTestWorld(*this);
+	if (!World)
+	{
+		return false;
+	}
+
+	ACC_PlayerCharacter* Player = World->SpawnActor<ACC_PlayerCharacter>();
+	TestNotNull(TEXT("Spawned player"), Player);
+	if (!Player)
+	{
+		return false;
+	}
+
+	const float AppliedDamage = Player->TakeDamage(25.0f, FDamageEvent(), nullptr, nullptr);
+
+	TestEqual(TEXT("TakeDamage returns applied damage once"), AppliedDamage, 25.0f);
+	TestEqual(TEXT("Player health is reduced once"), Player->GetCurrentHealth(), 75.0f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCCEnemyDeathCountsOnlyRealKillsTest,
+	"CristalCube.Regression.Cycle.KillCount.OnlyActualDeaths",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FCCEnemyDeathCountsOnlyRealKillsTest::RunTest(const FString& Parameters)
+{
+	using namespace CristalCube::Tests;
+
+	UWorld* World = CreateTestWorld(*this);
+	if (!World)
+	{
+		return false;
+	}
+
+	ACC_EnemyManager* EnemyManager = World->SpawnActor<ACC_EnemyManager>();
+	ACC_CycleManager* CycleManager = World->SpawnActor<ACC_CycleManager>();
+
+	TestNotNull(TEXT("Spawned enemy manager"), EnemyManager);
+	TestNotNull(TEXT("Spawned cycle manager"), CycleManager);
+	if (!EnemyManager || !CycleManager)
+	{
+		return false;
+	}
+
+	CycleManager->CycleConfigs = { MakeCycleConfig(1) };
+	EnemyManager->OnEnemyKilled.AddDynamic(CycleManager, &ACC_CycleManager::HandleEnemyKilled);
+	CycleManager->StartFirstCycle();
+
+	AActor* CleanupEnemy = World->SpawnActor<AActor>();
+	AActor* KilledEnemy = World->SpawnActor<AActor>();
+
+	TestNotNull(TEXT("Spawned cleanup enemy"), CleanupEnemy);
+	TestNotNull(TEXT("Spawned killed enemy"), KilledEnemy);
+	if (!CleanupEnemy || !KilledEnemy)
+	{
+		return false;
+	}
+
+	EnemyManager->RegisterEnemy(CleanupEnemy);
+	EnemyManager->RegisterEnemy(KilledEnemy);
+
+	EnemyManager->UnregisterEnemy(CleanupEnemy);
+	TestEqual(TEXT("Cleanup unregister does not increase kill count"), CycleManager->GetKillsThisCycle(), 0);
+
+	EnemyManager->NotifyEnemyKilled(KilledEnemy);
+	TestEqual(TEXT("Explicit kill notification increases kill count"), CycleManager->GetKillsThisCycle(), 1);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCCCycleClearFlowRegressionTest,
+	"CristalCube.Regression.Cycle.ClearFlow.CompletesOnRequiredKills",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FCCCycleClearFlowRegressionTest::RunTest(const FString& Parameters)
+{
+	using namespace CristalCube::Tests;
+
+	UWorld* World = CreateTestWorld(*this);
+	if (!World)
+	{
+		return false;
+	}
+
+	ACC_CycleManager* CycleManager = World->SpawnActor<ACC_CycleManager>();
+	TestNotNull(TEXT("Spawned cycle manager"), CycleManager);
+	if (!CycleManager)
+	{
+		return false;
+	}
+
+	CycleManager->CycleConfigs = { MakeCycleConfig(2) };
+	CycleManager->StartFirstCycle();
+
+	CycleManager->HandleEnemyKilled(nullptr);
+	TestTrue(TEXT("Cycle remains active before kill target is met"), CycleManager->bCycleActive);
+	TestEqual(TEXT("Kill count after first kill"), CycleManager->GetKillsThisCycle(), 1);
+
+	CycleManager->HandleEnemyKilled(nullptr);
+	TestFalse(TEXT("Cycle stops once required kills are reached"), CycleManager->bCycleActive);
+	TestEqual(TEXT("Kill count reaches requirement"), CycleManager->GetKillsThisCycle(), 2);
+	TestEqual(TEXT("Kill progress is clamped to completion"), CycleManager->GetKillProgress(), 1.0f);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FCCCubeClearRewardApplicationTest,
+	"CristalCube.Regression.Rewards.ApplyHealAndStatBoost",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FCCCubeClearRewardApplicationTest::RunTest(const FString& Parameters)
+{
+	using namespace CristalCube::Tests;
+
+	UWorld* World = CreateTestWorld(*this);
+	if (!World)
+	{
+		return false;
+	}
+
+	ACC_PlayerCharacter* Player = World->SpawnActor<ACC_PlayerCharacter>();
+	TestNotNull(TEXT("Spawned player"), Player);
+	if (!Player)
+	{
+		return false;
+	}
+
+	Player->TakeDamage(40.0f, FDamageEvent(), nullptr, nullptr);
+	TestEqual(TEXT("Player health after taking damage"), Player->GetCurrentHealth(), 60.0f);
+
+	FCubeClearReward HealReward;
+	HealReward.RewardType = ECubeClearRewardType::HealFull;
+	HealReward.DisplayName = FText::FromString(TEXT("Full Heal"));
+
+	TestTrue(TEXT("Heal reward applies"), Player->ApplyCubeClearReward(HealReward));
+	TestEqual(TEXT("Heal reward restores full health"), Player->GetCurrentHealth(), 100.0f);
+
+	FCubeClearReward StatReward;
+	StatReward.RewardType = ECubeClearRewardType::StatBoost;
+	StatReward.StatUpgradeType = EUpgradeType::Health;
+	StatReward.StatValue = 0.5f;
+	StatReward.DisplayName = FText::FromString(TEXT("Max Health Up"));
+
+	TestTrue(TEXT("Stat reward applies"), Player->ApplyCubeClearReward(StatReward));
+	TestEqual(TEXT("Health multiplier increases"), Player->GetPlayerStats().BasicStats.HealthMultiplier, 1.5f);
+	TestEqual(TEXT("Max health scales from the captured base value"), Player->GetMaxHealth(), 150.0f);
+	TestEqual(TEXT("Full-health player stays full after health boost"), Player->GetCurrentHealth(), 150.0f);
+
+	return true;
+}
+
+#endif


### PR DESCRIPTION
## 배경

현재 `CC_CubeSystemTester`, `CC_TileSystemTester` 같은 tester actor 방식은 디버그/수동 확인에는 도움이 되지만, 회귀 방지 수단으로는 부족했습니다.

구체적으로는 다음 문제가 있었습니다.
- 테스트를 실행하려면 레벨에 actor를 배치하고 플레이를 직접 돌려야 합니다.
- 결과가 `UE_LOG` 중심이라서 사람이 로그를 읽어야 하고, 실패가 자동으로 빌드/검증 실패로 이어지지 않습니다.
- 실제 게임 로직과 테스트 로직이 actor 생명주기/레벨 구성에 강하게 묶여 있어서, 핵심 회귀를 빠르게 재현하기 어렵습니다.
- `CC_TileSystemTester`는 사실상 주석 처리된 상태라 현재 기준의 안전망 역할을 하지 못합니다.

이번 PR은 “완벽한 테스트 체계”를 만들기보다, 지금 바로 회귀를 막을 수 있는 최소한의 자동 검증 기반을 추가하는 데 집중했습니다.

## 이번 PR에서 변경한 내용

### 1. tester actor 의존도를 낮추고 Unreal Automation Test 기반 회귀 테스트 추가
`Source/CristalCube/Test/CC_RegressionAutomationTests.cpp`를 추가해서 Editor automation에서 돌릴 수 있는 최소 회귀 테스트를 만들었습니다.

추가한 테스트는 다음과 같습니다.
- `CristalCube.Regression.Player.Damage.SingleApplication`
  - 플레이어 데미지가 한 번만 적용되는지 검증합니다.
  - 기존 `ACC_PlayerCharacter::TakeDamage()`가 `Super::TakeDamage()` 이후 체력을 한 번 더 깎는 구조였던 회귀를 막습니다.
- `CristalCube.Regression.Cycle.KillCount.OnlyActualDeaths`
  - 단순 unregister/cleanup은 킬 카운트에 반영되지 않고, 실제 사망 알림만 카운트되는지 검증합니다.
- `CristalCube.Regression.Cycle.ClearFlow.CompletesOnRequiredKills`
  - 사이클 시작 후 요구 킬 수를 채우면 `bCycleActive`가 종료 상태로 바뀌고 진행도가 1.0으로 고정되는지 검증합니다.
- `CristalCube.Regression.Rewards.ApplyHealAndStatBoost`
  - `HealFull`, `StatBoost(Health)` 보상이 실제 플레이어 상태에 반영되는지 검증합니다.

### 2. 플레이어 데미지/보상 적용 경로 정리
- `ACC_PlayerCharacter::TakeDamage()`에서 체력을 다시 차감하던 중복 로직을 제거했습니다.
- cube clear 보상 적용을 플레이어 레벨에서 처리할 수 있도록 최소 API를 추가했습니다.
  - `ApplyCubeClearReward()`
  - `ApplyStatUpgrade()`
- `HealFull`, `StatBoost`, `WeaponUpgrade`의 핵심 경로를 코드상으로 연결했습니다.
- `SkillGrant`는 아직 실제 지급 경로가 프로젝트에 정리돼 있지 않아 이번 PR에서는 명시적으로 미구현 경고를 남기도록 했습니다.

### 3. Health stat 적용 시 누적 드리프트 방지
보상/스탯 재적용이 반복될 때 현재 체력/최대 체력을 다시 기준값으로 삼아 곱해 버리는 문제가 생기지 않도록, 플레이어의 base stat 스냅샷을 잡고 그 값을 기준으로 최종 수치를 계산하도록 바꿨습니다.

이 변경으로 다음 같은 회귀를 막습니다.
- Health multiplier를 여러 번 적용할 때 최대 체력이 의도보다 과하게 불어나는 문제
- 보상 적용 순서에 따라 체력 수치가 비정상적으로 누적되는 문제

### 4. 적 사망과 unregister를 분리
기존에는 `ACC_CycleManager`가 사실상 `EnemyManager::OnEnemyUnregistered`에 기대고 있어서, 정리/비활성화/EndPlay 같은 경로도 킬로 집계될 여지가 있었습니다.

이번 PR에서는 다음처럼 분리했습니다.
- `ACC_EnemyManager::NotifyEnemyKilled()` 추가
- `ACC_CycleManager`는 `OnEnemyKilled`에만 반응하도록 변경
- `ACC_EnemyCharacter::Die()`에서 실제 사망 시점에만 kill notification을 보내도록 변경

즉, “적이 사라졌다”와 “적을 처치했다”를 같은 이벤트로 다루지 않도록 정리했습니다.

### 5. legacy tester actor 정리
- `CC_CubeSystemTester`의 `bAutoRunTests` 기본값을 `false`로 바꿨습니다.
- 수동 tester actor가 실행되더라도, 이제는 `CristalCube.Regression.*` automation test를 우선 사용하라는 경고 로그를 남기도록 했습니다.

tester actor를 완전히 삭제하지는 않았습니다.
이유는 레벨 기반 디버그 도구로는 아직 참고 가치가 조금 남아 있기 때문입니다. 다만 회귀 방지의 기준은 이번 PR부터 automation test 쪽으로 옮기려는 의도입니다.

## 테스트 실행 / 확인 방법

### Editor Automation에서 실행
Unreal Editor의 Automation 창(Session Frontend / Automation)에서 아래 테스트들을 실행하면 됩니다.
- `CristalCube.Regression.Player.Damage.SingleApplication`
- `CristalCube.Regression.Cycle.KillCount.OnlyActualDeaths`
- `CristalCube.Regression.Cycle.ClearFlow.CompletesOnRequiredKills`
- `CristalCube.Regression.Rewards.ApplyHealAndStatBoost`

또는 `CristalCube.Regression` 필터로 한 번에 확인할 수 있습니다.

### 커맨드라인 예시
로컬에 UE 5.6 Editor 경로가 잡혀 있다면 아래처럼 실행할 수 있습니다.

```bash
/Path/To/UnrealEditor \
  /absolute/path/to/CristalCube.uproject \
  -ExecCmds="Automation RunTests CristalCube.Regression; Quit" \
  -unattended -nop4 -nosplash -NullRHI -log
```

### 이번 작업에서 실제 수행한 검증
현재 작업 환경에서는 Unreal Editor/UBT 실행 경로를 확인하지 못해서, 실제 컴파일/automation 실행까지는 수행하지 못했습니다.
대신 아래는 확인했습니다.
- `git diff --check`
- 선언/정의 연결 점검
- 새 테스트 코드가 참조하는 런타임 경로 연결 점검

즉, 코드/구조 정리는 끝냈지만, 엔진이 설치된 환경에서 한 번 실제 automation 실행 확인이 필요합니다.

## 리뷰어가 특히 봐주면 좋은 포인트

- `ACC_PlayerCharacter::TakeDamage()`가 이제 실제로 한 번만 체력을 차감하는지
- `ACC_EnemyManager -> ACC_CycleManager` 연결이 “실제 사망만 카운트” 하도록 충분히 분리됐는지
- `ApplyCubeClearReward()`의 최소 구현 범위(`HealFull`, `StatBoost`, `WeaponUpgrade`)가 현재 게임 흐름과 맞는지
- Health multiplier 계산이 base stat 기준으로 안정적으로 동작하는지
- 새 automation test가 현재 프로젝트의 Editor automation 관행과 충돌하지 않는지

## 아직 자동화하지 못한 범위 / 한계

이번 PR에서 일부러 남긴 범위도 있습니다.
- `SkillGrant` 보상은 실제 지급 경로가 아직 정리되지 않아 자동화하지 못했습니다.
- widget/input mode까지 포함한 `ACC_MainGameMode`의 UI 표시 흐름 전체는 자동화하지 못했습니다.
- 실제 맵/스포너/전투 연동까지 포함한 end-to-end 테스트는 아직 없습니다.
- 기존 `CC_TileSystemTester`가 다루던 타일/큐브 이동 계열은 이번 PR 범위에서는 손대지 않았습니다.

## 후속 제안

후속 PR에서는 아래 순서가 현실적이라고 봅니다.
1. `SkillGrant`/`WeaponUpgrade` 보상 경로를 데이터 의존성 포함해서 더 명확히 정리
2. `ACC_MainGameMode`의 cube clear -> reward selection -> next cycle 흐름을 UI 제외/포함 두 단계로 테스트 분리
3. tile/cube 전환 계열도 지금처럼 actor tester가 아니라 automation test나 functional test로 이전
4. CI 환경에서 `CristalCube.Regression.*`를 돌릴 수 있게 엔진 경로/실행 스크립트 정리
